### PR TITLE
Disable context menu over RTCVideoView (#8)

### DIFF
--- a/lib/src/native/mediadevices_impl.dart
+++ b/lib/src/native/mediadevices_impl.dart
@@ -33,7 +33,8 @@ class MediaDeviceNative extends MediaDevices {
   @override
   Future<MediaStream> getDisplayMedia(
       Map<String, dynamic> mediaConstraints) async {
-    throw UnsupportedError('getDisplayMedia is not supported on Android platform');
+    throw UnsupportedError(
+        'getDisplayMedia is not supported on Android platform');
   }
 
   @override

--- a/lib/src/native/rtc_rtp_sender_impl.dart
+++ b/lib/src/native/rtc_rtp_sender_impl.dart
@@ -11,8 +11,8 @@ import 'media_stream_track_impl.dart';
 import 'utils.dart';
 
 class RTCRtpSenderNative extends RTCRtpSender {
-  RTCRtpSenderNative(this._id, this._track, this._parameters,
-      this._ownsTrack, this._peerConnectionId);
+  RTCRtpSenderNative(this._id, this._track, this._parameters, this._ownsTrack,
+      this._peerConnectionId);
 
   factory RTCRtpSenderNative.fromMap(Map<dynamic, dynamic> map,
       {required String peerConnectionId}) {

--- a/lib/src/native/rtc_video_view_impl.dart
+++ b/lib/src/native/rtc_video_view_impl.dart
@@ -13,12 +13,14 @@ class RTCVideoView extends StatelessWidget {
     Key? key,
     this.objectFit = RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
     this.mirror = false,
+    this.enableContextMenu = true,
     this.filterQuality = FilterQuality.low,
   }) : super(key: key);
 
   final RTCVideoRenderer _renderer;
   final RTCVideoViewObjectFit objectFit;
   final bool mirror;
+  final bool enableContextMenu;
   final FilterQuality filterQuality;
 
   RTCVideoRendererNative get videoRenderer =>

--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -51,6 +51,8 @@ class RTCVideoRendererWeb extends VideoRenderer {
 
   bool mirror = false;
 
+  bool enableContextMenu = true;
+
   final _subscriptions = <StreamSubscription>[];
 
   String _objectFit = 'contain';
@@ -210,7 +212,9 @@ class RTCVideoRendererWeb extends VideoRenderer {
         ..style.transform = mirror ? 'rotateY(0.5turn)' : ''
         ..srcObject = _videoStream
         ..id = _elementIdForVideo
-        ..setAttribute('playsinline', 'true');
+        ..setAttribute('playsinline', 'true')
+        ..setAttribute(
+            'oncontextmenu', enableContextMenu ? '' : 'return false;');
 
       _subscriptions.add(
         element.onCanPlay.listen((dynamic _) {

--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -12,12 +12,14 @@ class RTCVideoView extends StatefulWidget {
     Key? key,
     this.objectFit = RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
     this.mirror = false,
+    this.enableContextMenu = true,
     this.filterQuality = FilterQuality.low,
   }) : super(key: key);
 
   final RTCVideoRenderer _renderer;
   final RTCVideoViewObjectFit objectFit;
   final bool mirror;
+  final bool enableContextMenu;
   final FilterQuality filterQuality;
 
   @override
@@ -35,6 +37,7 @@ class _RTCVideoViewState extends State<RTCVideoView> {
     super.initState();
     widget._renderer.delegate.addListener(_onRendererListener);
     videoRenderer.mirror = widget.mirror;
+    videoRenderer.enableContextMenu = widget.enableContextMenu;
     videoRenderer.objectFit =
         widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
             ? 'contain'
@@ -56,6 +59,7 @@ class _RTCVideoViewState extends State<RTCVideoView> {
     super.didUpdateWidget(oldWidget);
     Timer(
         Duration(milliseconds: 10), () => videoRenderer.mirror = widget.mirror);
+    videoRenderer.enableContextMenu = widget.enableContextMenu;
     videoRenderer.objectFit =
         widget.objectFit == RTCVideoViewObjectFit.RTCVideoViewObjectFitContain
             ? 'contain'


### PR DESCRIPTION
## Synopsis

Этот PR добавляет возможность отключать в вебе стандартное контекстное меню на ПКМ над `RTCVideoView` с помощью флажка.

Контекстное меню отключается с помощью добавления атрибута `oncontextmenu="return false";` в веб реализацию `RTCVideoRenderer`'а.

## Checklist

- Created PR:
  - [x] In draft mode
  - [x] Name contains Draft: prefix
  - [x] Name contains issue reference
  - [x] Has k:: labels applied
  - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
  - [x] and approved
- [x] Review is completed and changes are approved
- Before merge:
  - [x] Milestone is set
  - [x] PR's name and description are correct and up-to-date
  - [x] Draft: prefix is removed
  - [x] All temporary labels are removed