### PR TITLE
Fix mirroring issues with `RTCVideoRenderer` (#14)

### DIFF
--- a/lib/src/interface/rtc_video_renderer.dart
+++ b/lib/src/interface/rtc_video_renderer.dart
@@ -55,6 +55,8 @@ abstract class VideoRenderer extends ValueNotifier<RTCVideoValue> {
   bool get muted;
   set muted(bool mute);
 
+  set mirror(bool mirror);
+
   ///Return true if the audioOutput have been succesfully changed
   Future<bool> audioOutput(String deviceId);
 

--- a/lib/src/native/rtc_video_renderer_impl.dart
+++ b/lib/src/native/rtc_video_renderer_impl.dart
@@ -35,6 +35,11 @@ class RTCVideoRendererNative extends VideoRenderer {
   MediaStream? get srcObject => _srcObject;
 
   @override
+  set mirror(bool mirror) {
+    // No-op. Mirroring is done through [RTCViewView].
+  }
+
+  @override
   set srcObject(MediaStream? stream) {
     if (textureId == null) throw 'Call initialize before setting the stream';
 

--- a/lib/src/rtc_video_renderer.dart
+++ b/lib/src/rtc_video_renderer.dart
@@ -22,6 +22,8 @@ class RTCVideoRenderer {
 
   MediaStream? get srcObject => _delegate.srcObject;
 
+  set mirror(bool mirror) => _delegate.mirror = mirror;
+
   set muted(bool mute) => _delegate.muted = mute;
 
   set audioOutput(String deviceId) => _delegate.audioOutput(deviceId);

--- a/lib/src/web/rtc_video_view_impl.dart
+++ b/lib/src/web/rtc_video_view_impl.dart
@@ -57,6 +57,7 @@ class _RTCVideoViewState extends State<RTCVideoView> {
   @override
   void didUpdateWidget(RTCVideoView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    videoRenderer.mirror = widget.mirror;
     Timer(
         Duration(milliseconds: 10), () => videoRenderer.mirror = widget.mirror);
     videoRenderer.enableContextMenu = widget.enableContextMenu;


### PR DESCRIPTION
## Synopsis

Этот PR правит работу `mirror: true` на `RTCVideoView`.  
Проблема возникла в связи с #1, где от флажка `mirror: true` на `RTCVideoView` не осталось никакого эффекта на Web'е. В данном PR был выделен `mirror` setter над `RTCVideoRenderer`, который при создании `VideoElement`'а сразу прописывает ему `rotateY(0.5turn)`.  

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests