### PR TITLE
Draft: Add MediaStreamTrack.onEnded callback for the Android

### DIFF
--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/MediaStreamTrackProxy.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/MediaStreamTrackProxy.kt
@@ -39,9 +39,24 @@ class MediaStreamTrackProxy(
      */
     private var isStopped: Boolean = false
 
+    /**
+     * List of [EventObserver] for this [MediaStreamTrackProxy].
+     */
+    private var eventObservers: HashSet<EventObserver> = HashSet()
+
     init {
         TrackRepository.addTrack(this)
     }
+
+    companion object {
+        /**
+         * Observer of the [MediaStreamTrackProxy] events.
+         */
+        interface EventObserver {
+            fun onEnded()
+        }
+    }
+
 
     /**
      * Returns ID of the underlying [MediaStreamTrack].
@@ -68,6 +83,30 @@ class MediaStreamTrackProxy(
      */
     fun deviceId(): String {
         return deviceId
+    }
+
+    /**
+     * Creates broadcaster to the all [eventObservers] of this [MediaStreamTrackProxy].
+     *
+     * @return [EventObserver] which will broadcast calls to the all [eventObservers].
+     */
+    fun observableEventBroadcaster(): EventObserver {
+        return object : EventObserver {
+            override fun onEnded() {
+                eventObservers.forEach {
+                    it.onEnded()
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds [EventObserver] for this [MediaStreamTrackProxy].
+     *
+     * @param eventObserver [EventObserver] which will be subscribed.
+     */
+    fun addEventObserver(eventObserver: EventObserver) {
+        eventObservers.add(eventObserver)
     }
 
     /**

--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/PeerConnectionProxy.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/PeerConnectionProxy.kt
@@ -273,6 +273,14 @@ class PeerConnectionProxy(val id: Int, peer: PeerConnection) :
     }
 
     /**
+     * Notifies [RtpReceiverProxy] that ]
+     */
+    fun receiverEnded(endedReceiver: RtpReceiver) {
+        val receiver = receivers[endedReceiver.id()]
+        receiver?.ended()
+    }
+
+    /**
      * Disposes the underlying [PeerConnection], [RtpSenderProxy]s,
      * [RtpReceiverProxy] and notifies all [onDispose] subscribers about it.
      */

--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/PeerObserver.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/PeerObserver.kt
@@ -92,6 +92,15 @@ class PeerObserver : PeerConnection.Observer {
         }
     }
 
+    override fun onRemoveTrack(receiver: RtpReceiver?) {
+        if (receiver != null) {
+            Handler(Looper.getMainLooper()).post {
+                peer?.receiverEnded(receiver)
+            }
+        }
+        super.onRemoveTrack(receiver)
+    }
+
     override fun onIceConnectionReceivingChange(receiving: Boolean) {}
     override fun onIceCandidatesRemoved(candidates: Array<out WIceCandidate>?) {}
     override fun onAddStream(stream: MediaStream?) {}

--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/RtpReceiverProxy.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/proxy/RtpReceiverProxy.kt
@@ -34,6 +34,13 @@ class RtpReceiverProxy(receiver: RtpReceiver) : Proxy<RtpReceiver> {
     }
 
     /**
+     * Notifies [RtpReceiverProxy], that it's [MediaStreamTrackProxy] is ended.
+     */
+    fun ended() {
+        track?.observableEventBroadcaster()?.onEnded()
+    }
+
+    /**
      * Synchronizes the [MediaStreamTrackProxy] of this [RtpReceiverProxy] with
      * the underlying [RtpReceiver].
      */

--- a/lib/src/platform/native/media_stream_track.dart
+++ b/lib/src/platform/native/media_stream_track.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 import '/src/api/channel.dart';
@@ -9,7 +11,10 @@ class NativeMediaStreamTrack extends MediaStreamTrack {
   /// Creates a [NativeMediaStreamTrack] basing on the [Map] received from the
   /// native side.
   NativeMediaStreamTrack.fromMap(dynamic map) {
-    _chan = methodChannel('MediaStreamTrack', map['channelId']);
+    var channelId = map['channelId'];
+    _chan = methodChannel('MediaStreamTrack', channelId);
+    _eventChan = eventChannel('MediaStreamTrackEvent', channelId);
+    _eventSub = _eventChan.receiveBroadcastStream().listen(eventListener);
     _id = map['id'];
     _deviceId = map['deviceId'];
     _kind = MediaKind.values[map['kind']];
@@ -35,6 +40,31 @@ class NativeMediaStreamTrack extends MediaStreamTrack {
 
   /// [MethodChannel] used for the messaging with a native side.
   late MethodChannel _chan;
+
+  /// [EventChannel] from which all [PeerConnection] events will be received.
+  late EventChannel _eventChan;
+
+  /// [_eventChan] subscription to the [PeerConnection] events.
+  late StreamSubscription<dynamic>? _eventSub;
+
+  /// `on_ended` event subcriber.
+  OnEndedCallback? _onEnded;
+
+  /// Listener for the all [MediaStreamTrack] events received from the
+  /// native side.
+  void eventListener(dynamic event) {
+    final dynamic e = event;
+    switch (e['event']) {
+      case 'onEnded':
+        _onEnded?.call();
+        break;
+    }
+  }
+
+  @override
+  void onEnded(OnEndedCallback cb) {
+    _onEnded = cb;
+  }
 
   @override
   String id() {
@@ -67,9 +97,10 @@ class NativeMediaStreamTrack extends MediaStreamTrack {
     await _chan.invokeMethod('stop');
   }
 
-  // TODO(evdokimovs): implement disposing for native side
   @override
-  Future<void> dispose() async {}
+  Future<void> dispose() async {
+    await _eventSub?.cancel();
+  }
 
   @override
   Future<MediaStreamTrack> clone() async {

--- a/lib/src/platform/track.dart
+++ b/lib/src/platform/track.dart
@@ -1,5 +1,8 @@
 import '/src/model/track.dart';
 
+/// Typedef for the `on_ended` callback.
+typedef OnEndedCallback = void Function();
+
 /// Abstract representation of a single media unit on native or web side.
 abstract class MediaStreamTrack {
   /// Returns unique identifier of this [MediaStreamTrack].
@@ -32,6 +35,9 @@ abstract class MediaStreamTrack {
   /// This action will unheld the device in case of the last local
   /// [MediaStreamTrack]s of some device.
   Future<void> stop();
+
+  /// Subscribes provided callback to the `onEnded` events of this [MediaStreamTrack].
+  void onEnded(OnEndedCallback cb);
 
   /// Creates a new instance of [MediaStreamTrack], which will depend on the same
   /// media source as this [MediaStreamTrack].

--- a/lib/src/platform/web/media_stream_track.dart
+++ b/lib/src/platform/web/media_stream_track.dart
@@ -22,6 +22,13 @@ class WebMediaStreamTrack extends MediaStreamTrack {
   }
 
   @override
+  void onEnded(OnEndedCallback cb) {
+    jsTrack.onEnded.listen((event) {
+      cb.call();
+    });
+  }
+
+  @override
   bool isEnabled() {
     return jsTrack.enabled ?? false;
   }


### PR DESCRIPTION
## Synopsis

This PR implements `MediaStreamTrack.onEnded` callback for the Android platform.

Because Android WebRTC SDK doesn't provides API for the `onChanged` callback of `MediaStreamTrack`, we will fire `onEnded` callback based on the `PeerConnection` `Observer` API.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests