### PR TITLE
Fix `WebAudioRenderer` not removing its audio element

### DIFF
--- a/lib/src/platform/web/audio_renderer.dart
+++ b/lib/src/platform/web/audio_renderer.dart
@@ -38,6 +38,7 @@ class WebAudioRenderer extends AudioRenderer {
   Future<void> dispose() async {
     _srcObject = null;
     _element?.srcObject = null;
+    _element?.remove();
     final audioManager = html.document.getElementById(_elementIdForAudioManager)
         as html.DivElement?;
     if (audioManager != null && !audioManager.hasChildNodes()) {

--- a/lib/src/platform/web/audio_renderer.dart
+++ b/lib/src/platform/web/audio_renderer.dart
@@ -39,6 +39,7 @@ class WebAudioRenderer extends AudioRenderer {
     _srcObject = null;
     _element?.srcObject = null;
     _element?.remove();
+    _element = null;
     final audioManager = html.document.getElementById(_elementIdForAudioManager)
         as html.DivElement?;
     if (audioManager != null && !audioManager.hasChildNodes()) {


### PR DESCRIPTION
## Synopsis

This PR fixes `WebAudioRenderer` not removing its audio element in `dispose` function.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests