### PR TITLE
Implement Intent based Bluetooth headset detection

### DIFF
--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/MediaDevices.kt
@@ -1,9 +1,15 @@
 package com.cloudwebrtc.webrtc
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothHeadset
 import android.bluetooth.BluetoothProfile
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.media.AudioManager
+import android.os.Handler
+import android.os.Looper
 import com.cloudwebrtc.webrtc.exception.OverconstrainedException
 import com.cloudwebrtc.webrtc.model.*
 import com.cloudwebrtc.webrtc.proxy.AudioMediaTrackSource
@@ -53,7 +59,7 @@ private const val BLUETOOTH_HEADSET_DEVICE_ID: String = "bluetooth-headset"
  * @property state Global state used for enumerating devices and creation new
  * [MediaStreamTrackProxy]s.
  */
-class MediaDevices(val state: State) {
+class MediaDevices(val state: State) : BroadcastReceiver() {
   /** [BluetoothAdapter] used for detecting whether bluetooth headset is connected or not. */
   private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
 
@@ -93,22 +99,43 @@ class MediaDevices(val state: State) {
   }
 
   init {
+    val filter = IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED)
+    state.getAppContext().registerReceiver(this, filter)
     bluetoothAdapter.getProfileProxy(
         state.getAppContext(),
         object : BluetoothProfile.ServiceListener {
           override fun onServiceConnected(profile: Int, proxy: BluetoothProfile?) {
-            eventBroadcaster().onDeviceChange()
             if (proxy!!.connectedDevices.isNotEmpty()) {
-              isBluetoothHeadsetConnected = true
+              setHeadsetState(true)
             }
           }
 
           override fun onServiceDisconnected(profile: Int) {
-            isBluetoothHeadsetConnected = false
-            eventBroadcaster().onDeviceChange()
+            setHeadsetState(false)
           }
         },
         BluetoothProfile.HEADSET)
+  }
+
+  override fun onReceive(ctx: Context?, intent: Intent?) {
+    val bluetoothHeadsetState = intent?.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED)
+    if (bluetoothHeadsetState == BluetoothHeadset.STATE_CONNECTED) {
+      setHeadsetState(true)
+    } else if (bluetoothHeadsetState == BluetoothHeadset.STATE_DISCONNECTED) {
+      setHeadsetState(false)
+    }
+  }
+
+  /**
+   * Sets [isBluetoothHeadsetConnected] to the provided value.
+   *
+   * Fires [EventObserver.onDeviceChange] notification if it changed.
+   */
+  private fun setHeadsetState(isConnected: Boolean) {
+    if (isBluetoothHeadsetConnected != isConnected) {
+      isBluetoothHeadsetConnected = isConnected
+      Handler(Looper.getMainLooper()).post { eventBroadcaster().onDeviceChange() }
+    }
   }
 
   /**

--- a/android/src/main/kotlin/com/cloudwebrtc/webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/cloudwebrtc/webrtc/MediaDevices.kt
@@ -99,8 +99,9 @@ class MediaDevices(val state: State) : BroadcastReceiver() {
   }
 
   init {
-    val filter = IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED)
-    state.getAppContext().registerReceiver(this, filter)
+    state
+        .getAppContext()
+        .registerReceiver(this, IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED))
     bluetoothAdapter.getProfileProxy(
         state.getAppContext(),
         object : BluetoothProfile.ServiceListener {
@@ -118,7 +119,8 @@ class MediaDevices(val state: State) : BroadcastReceiver() {
   }
 
   override fun onReceive(ctx: Context?, intent: Intent?) {
-    val bluetoothHeadsetState = intent?.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED)
+    val bluetoothHeadsetState =
+        intent?.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED)
     if (bluetoothHeadsetState == BluetoothHeadset.STATE_CONNECTED) {
       setHeadsetState(true)
     } else if (bluetoothHeadsetState == BluetoothHeadset.STATE_DISCONNECTED) {


### PR DESCRIPTION
## Synopsis

This PR adds Bluetooth headset detection functional based on Android Intents. Old mechanism based on `BluetoothAdapter` remains, because it's needed for headset detection on application start and for better support on different devices.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests