### PR TITLE
Refactor `getMedia` method

### DIFF
--- a/crates/native/src/devices.rs
+++ b/crates/native/src/devices.rs
@@ -203,10 +203,8 @@ impl Webrtc {
     ) -> anyhow::Result<Option<u16>> {
         let count: i16 =
             self.audio_device_module.recording_devices().try_into()?;
-        println!("after count: {count}");
         for i in 0..count {
             let (_, id) = self.audio_device_module.recording_device_name(i)?;
-            println!("after device name");
             if id == device_id.to_string() {
                 #[allow(clippy::cast_sign_loss)]
                 return Ok(Some(i as u16));

--- a/crates/native/src/devices.rs
+++ b/crates/native/src/devices.rs
@@ -203,8 +203,10 @@ impl Webrtc {
     ) -> anyhow::Result<Option<u16>> {
         let count: i16 =
             self.audio_device_module.recording_devices().try_into()?;
+        println!("after count: {count}");
         for i in 0..count {
             let (_, id) = self.audio_device_module.recording_device_name(i)?;
+            println!("after device name");
             if id == device_id.to_string() {
                 #[allow(clippy::cast_sign_loss)]
                 return Ok(Some(i as u16));

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use anyhow::{bail, Context};
-use dashmap::mapref::one::RefMut;
 use derive_more::{AsRef, Display, From};
 use libwebrtc_sys as sys;
 use sys::TrackEventObserver;
@@ -25,31 +24,45 @@ impl Webrtc {
     ) -> anyhow::Result<Vec<api::MediaStreamTrack>> {
         let mut result = Vec::new();
 
-        let create_tracks = || -> anyhow::Result<()> {
+        let inner_get_media = || -> anyhow::Result<()> {
             if let Some(video) = constraints.video {
-                let source = self.get_or_create_video_source(&video)?;
-                let track = self.create_video_track(source)?;
-                result.push(api::MediaStreamTrack::from(&*track));
+                let src = self.get_or_create_video_source(&video)?;
+                let track = self.create_video_track(Arc::clone(&src));
+                if let Err(err) = track {
+                    if Arc::strong_count(&src) == 2 {
+                        self.video_sources.remove(&src.device_id);
+                    };
+                    return Err(err);
+                }
+                result.push(track?);
             }
 
             if let Some(audio) = constraints.audio {
-                let source = self.get_or_create_audio_source(&audio)?;
-                let track = self.create_audio_track(source)?;
-                result.push(api::MediaStreamTrack::from(&*track));
+                let src = self.get_or_create_audio_source(&audio)?;
+                let track = self.create_audio_track(src);
+                if let Err(err) = track {
+                    if Arc::get_mut(self.audio_source.as_mut().unwrap())
+                        .is_some()
+                    {
+                        self.audio_source.take();
+                    }
+                    return Err(err);
+                }
+                result.push(track?);
             }
 
             Ok(())
         };
 
-        if let Err(e) = create_tracks() {
+        if let Err(err) = inner_get_media() {
             for track in &result {
                 self.dispose_track(track.id);
             }
 
-            return Err(e);
+            Err(err)
+        } else {
+            Ok(result)
         }
-
-        Ok(result)
     }
 
     /// Disposes a [`VideoTrack`] or [`AudioTrack`] by the provided `track_id`.
@@ -98,13 +111,15 @@ impl Webrtc {
     fn create_video_track(
         &mut self,
         source: Arc<VideoSource>,
-    ) -> anyhow::Result<RefMut<'_, VideoTrackId, VideoTrack>> {
+    ) -> anyhow::Result<api::MediaStreamTrack> {
         let track =
             VideoTrack::create_local(&self.peer_connection_factory, source)?;
 
-        let track = self.video_tracks.entry(track.id).or_insert(track);
+        let api_track = api::MediaStreamTrack::from(&track);
 
-        Ok(track)
+        self.video_tracks.insert(track.id, track);
+
+        Ok(api_track)
     }
 
     /// Creates a new [`VideoSource`] based on the given [`VideoConstraints`].
@@ -170,7 +185,7 @@ impl Webrtc {
     fn create_audio_track(
         &mut self,
         source: Arc<sys::AudioSourceInterface>,
-    ) -> anyhow::Result<RefMut<'_, AudioTrackId, AudioTrack>> {
+    ) -> anyhow::Result<api::MediaStreamTrack> {
         // PANIC: If there is a `sys::AudioSourceInterface` then we are sure
         //        that `current_device_id` is set in the `AudioDeviceModule`.
         let device_id =
@@ -179,9 +194,11 @@ impl Webrtc {
         let track =
             AudioTrack::new(&self.peer_connection_factory, source, device_id)?;
 
-        let track = self.audio_tracks.entry(track.id).or_insert(track);
+        let api_track = api::MediaStreamTrack::from(&track);
 
-        Ok(track)
+        self.audio_tracks.insert(track.id, track);
+
+        Ok(api_track)
     }
 
     /// Creates a new [`sys::AudioSourceInterface`] based on the given
@@ -283,9 +300,7 @@ impl Webrtc {
 
             match source {
                 MediaTrackSource::Local(source) => {
-                    Ok(api::MediaStreamTrack::from(
-                        self.create_video_track(source).unwrap().value(),
-                    ))
+                    Ok(self.create_video_track(source)?)
                 }
                 MediaTrackSource::Remote { mid, peer_id } => {
                     let peer = self.peer_connections.get(&peer_id).unwrap();
@@ -326,9 +341,7 @@ impl Webrtc {
 
             match source {
                 MediaTrackSource::Local(source) => {
-                    Ok(api::MediaStreamTrack::from(
-                        self.create_audio_track(source).unwrap().value(),
-                    ))
+                    Ok(self.create_audio_track(source)?)
                 }
                 MediaTrackSource::Remote { mid, peer_id } => {
                     let peer = self.peer_connections.get(&peer_id).unwrap();

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -26,14 +26,20 @@ impl Webrtc {
         let mut result = Vec::new();
 
         if let Some(video) = constraints.video {
+            println!("in video");
             let source = self.get_or_create_video_source(&video)?;
+            println!("after vsource");
             let track = self.create_video_track(source)?;
+            println!("after vtrack");
             result.push(api::MediaStreamTrack::from(&*track));
         }
 
         if let Some(audio) = constraints.audio {
+            println!("in audio");
             let source = self.get_or_create_audio_source(&audio)?;
+            println!("after asource");
             let track = self.create_audio_track(source)?;
+            println!("after atrack");
             result.push(api::MediaStreamTrack::from(&*track));
         }
 
@@ -181,11 +187,14 @@ impl Webrtc {
         let device_id = if let Some(device_id) = caps.device_id.clone() {
             AudioDeviceId(device_id)
         } else {
+            println!("no caps");
             // No device ID is provided so just pick the currently used.
             if self.audio_device_module.current_device_id.is_none() {
                 // `AudioDeviceModule` is not capturing anything at the moment,
                 // so we will use first available device (with `0` index).
+                println!("is none");
                 if self.audio_device_module.recording_devices() < 1 {
+                    println!("no devices");
                     bail!("Cannot find any available audio input device");
                 }
 
@@ -193,18 +202,21 @@ impl Webrtc {
                     self.audio_device_module.recording_device_name(0)?.1,
                 )
             } else {
+                println!("not none");
                 // PANIC: If there is a `sys::AudioSourceInterface` then we are
                 //        sure that `current_device_id` is set in the
                 //        `AudioDeviceModule`.
                 self.audio_device_module.current_device_id.clone().unwrap()
             }
         };
+        println!("device id here");
 
         let device_index = if let Some(index) =
             self.get_index_of_audio_recording_device(&device_id)?
         {
             index
         } else {
+            println!("no index");
             bail!(
                 "Cannot find audio device with the specified ID `{device_id}`",
             );
@@ -226,6 +238,8 @@ impl Webrtc {
 
             src
         };
+
+        println!("all is ok");
 
         Ok(src)
     }

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -25,22 +25,28 @@ impl Webrtc {
     ) -> anyhow::Result<Vec<api::MediaStreamTrack>> {
         let mut result = Vec::new();
 
-        if let Some(video) = constraints.video {
-            println!("in video");
-            let source = self.get_or_create_video_source(&video)?;
-            println!("after vsource");
-            let track = self.create_video_track(source)?;
-            println!("after vtrack");
-            result.push(api::MediaStreamTrack::from(&*track));
-        }
+        let create_tracks = || -> anyhow::Result<()> {
+            if let Some(video) = constraints.video {
+                let source = self.get_or_create_video_source(&video)?;
+                let track = self.create_video_track(source)?;
+                result.push(api::MediaStreamTrack::from(&*track));
+            }
 
-        if let Some(audio) = constraints.audio {
-            println!("in audio");
-            let source = self.get_or_create_audio_source(&audio)?;
-            println!("after asource");
-            let track = self.create_audio_track(source)?;
-            println!("after atrack");
-            result.push(api::MediaStreamTrack::from(&*track));
+            if let Some(audio) = constraints.audio {
+                let source = self.get_or_create_audio_source(&audio)?;
+                let track = self.create_audio_track(source)?;
+                result.push(api::MediaStreamTrack::from(&*track));
+            }
+
+            Ok(())
+        };
+
+        if let Err(e) = create_tracks() {
+            for track in &result {
+                self.dispose_track(track.id);
+            }
+
+            return Err(e);
         }
 
         Ok(result)
@@ -187,14 +193,11 @@ impl Webrtc {
         let device_id = if let Some(device_id) = caps.device_id.clone() {
             AudioDeviceId(device_id)
         } else {
-            println!("no caps");
             // No device ID is provided so just pick the currently used.
             if self.audio_device_module.current_device_id.is_none() {
                 // `AudioDeviceModule` is not capturing anything at the moment,
                 // so we will use first available device (with `0` index).
-                println!("is none");
                 if self.audio_device_module.recording_devices() < 1 {
-                    println!("no devices");
                     bail!("Cannot find any available audio input device");
                 }
 
@@ -202,21 +205,18 @@ impl Webrtc {
                     self.audio_device_module.recording_device_name(0)?.1,
                 )
             } else {
-                println!("not none");
                 // PANIC: If there is a `sys::AudioSourceInterface` then we are
                 //        sure that `current_device_id` is set in the
                 //        `AudioDeviceModule`.
                 self.audio_device_module.current_device_id.clone().unwrap()
             }
         };
-        println!("device id here");
 
         let device_index = if let Some(index) =
             self.get_index_of_audio_recording_device(&device_id)?
         {
             index
         } else {
-            println!("no index");
             bail!(
                 "Cannot find audio device with the specified ID `{device_id}`",
             );
@@ -238,8 +238,6 @@ impl Webrtc {
 
             src
         };
-
-        println!("all is ok");
 
         Ok(src)
     }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -6,9 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_webrtc
 )
 
-list(APPEND FLUTTER_FFI_PLUGIN_LIST
-)
-
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -17,8 +14,3 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
-
-foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
-  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
-  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
-endforeach(ffi_plugin)


### PR DESCRIPTION
## Synopsis

If there is any `Err` while calling `getMedia` the all created tracks must be disposed.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests