### PR TITLE
Dedup `track` events by track ID

### DIFF
--- a/crates/native/src/api.rs
+++ b/crates/native/src/api.rs
@@ -550,7 +550,7 @@ pub struct AudioConstraints {
 #[derive(Clone, Debug)]
 pub struct MediaStreamTrack {
     /// Unique identifier (GUID) of this [`MediaStreamTrack`].
-    pub id: u64,
+    pub id: String,
 
     /// Label identifying the track source, as in "internal microphone".
     pub device_id: String,
@@ -891,7 +891,7 @@ pub fn stop_transceiver(
 pub fn sender_replace_track(
     peer_id: u64,
     transceiver_index: u32,
-    track_id: Option<u64>,
+    track_id: Option<String>,
 ) -> anyhow::Result<()> {
     WEBRTC.lock().unwrap().sender_replace_track(
         peer_id,
@@ -940,31 +940,36 @@ pub fn set_audio_playout_device(device_id: String) -> anyhow::Result<()> {
 }
 
 /// Disposes the specified [`MediaStreamTrack`].
-pub fn dispose_track(track_id: u64) {
+pub fn dispose_track(track_id: String) {
     WEBRTC.lock().unwrap().dispose_track(track_id);
 }
 
 /// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#track-enabled
-pub fn set_track_enabled(track_id: u64, enabled: bool) -> anyhow::Result<()> {
-    WEBRTC.lock().unwrap().set_track_enabled(track_id, enabled)
+#[allow(clippy::needless_pass_by_value)]
+pub fn set_track_enabled(
+    track_id: String,
+    enabled: bool,
+) -> anyhow::Result<()> {
+    WEBRTC.lock().unwrap().set_track_enabled(&track_id, enabled)
 }
 
 /// Clones the specified [`MediaStreamTrack`].
-pub fn clone_track(track_id: u64) -> anyhow::Result<MediaStreamTrack> {
+pub fn clone_track(track_id: String) -> anyhow::Result<MediaStreamTrack> {
     WEBRTC.lock().unwrap().clone_track(track_id)
 }
 
 /// Registers an observer to the [`MediaStreamTrack`] events.
+#[allow(clippy::needless_pass_by_value)]
 pub fn register_track_observer(
     cb: StreamSink<TrackEvent>,
-    track_id: u64,
+    track_id: String,
 ) -> anyhow::Result<()> {
     WEBRTC
         .lock()
         .unwrap()
-        .register_track_observer(track_id, cb.into())
+        .register_track_observer(&track_id, cb.into())
 }
 
 /// Sets the provided [`OnDeviceChangeCallback`] as the callback to be called
@@ -982,7 +987,7 @@ pub fn set_on_device_changed(cb: StreamSink<()>) -> anyhow::Result<()> {
 /// an [`OnFrameCallbackInterface`].
 pub fn create_video_sink(
     sink_id: i64,
-    track_id: u64,
+    track_id: String,
     callback_ptr: u64,
 ) -> anyhow::Result<()> {
     let handler = unsafe {

--- a/crates/native/src/api.rs
+++ b/crates/native/src/api.rs
@@ -940,36 +940,42 @@ pub fn set_audio_playout_device(device_id: String) -> anyhow::Result<()> {
 }
 
 /// Disposes the specified [`MediaStreamTrack`].
-pub fn dispose_track(track_id: String) {
-    WEBRTC.lock().unwrap().dispose_track(track_id);
+pub fn dispose_track(track_id: String, kind: MediaType) {
+    WEBRTC.lock().unwrap().dispose_track(track_id, kind);
 }
 
 /// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID.
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#track-enabled
-#[allow(clippy::needless_pass_by_value)]
 pub fn set_track_enabled(
     track_id: String,
+    kind: MediaType,
     enabled: bool,
-) -> anyhow::Result<()> {
-    WEBRTC.lock().unwrap().set_track_enabled(&track_id, enabled)
-}
-
-/// Clones the specified [`MediaStreamTrack`].
-pub fn clone_track(track_id: String) -> anyhow::Result<MediaStreamTrack> {
-    WEBRTC.lock().unwrap().clone_track(track_id)
-}
-
-/// Registers an observer to the [`MediaStreamTrack`] events.
-#[allow(clippy::needless_pass_by_value)]
-pub fn register_track_observer(
-    cb: StreamSink<TrackEvent>,
-    track_id: String,
 ) -> anyhow::Result<()> {
     WEBRTC
         .lock()
         .unwrap()
-        .register_track_observer(&track_id, cb.into())
+        .set_track_enabled(track_id, kind, enabled)
+}
+
+/// Clones the specified [`MediaStreamTrack`].
+pub fn clone_track(
+    track_id: String,
+    kind: MediaType,
+) -> anyhow::Result<MediaStreamTrack> {
+    WEBRTC.lock().unwrap().clone_track(track_id, kind)
+}
+
+/// Registers an observer to the [`MediaStreamTrack`] events.
+pub fn register_track_observer(
+    cb: StreamSink<TrackEvent>,
+    track_id: String,
+    kind: MediaType,
+) -> anyhow::Result<()> {
+    WEBRTC
+        .lock()
+        .unwrap()
+        .register_track_observer(track_id, kind, cb.into())
 }
 
 /// Sets the provided [`OnDeviceChangeCallback`] as the callback to be called

--- a/crates/native/src/api.rs
+++ b/crates/native/src/api.rs
@@ -944,7 +944,8 @@ pub fn dispose_track(track_id: String, kind: MediaType) {
     WEBRTC.lock().unwrap().dispose_track(track_id, kind);
 }
 
-/// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID.
+/// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID and
+/// [`MediaType`].
 ///
 /// [1]: https://w3.org/TR/mediacapture-streams#track-enabled
 pub fn set_track_enabled(

--- a/crates/native/src/bridge_generated.rs
+++ b/crates/native/src/bridge_generated.rs
@@ -42,7 +42,10 @@ pub extern "C" fn wire_create_peer_connection(
         move || {
             let api_configuration = configuration.wire2api();
             move |task_callback| {
-                create_peer_connection(task_callback.stream_sink(), api_configuration)
+                create_peer_connection(
+                    task_callback.stream_sink(),
+                    api_configuration,
+                )
             }
         },
     )
@@ -64,7 +67,8 @@ pub extern "C" fn wire_create_offer(
         },
         move || {
             let api_peer_id = peer_id.wire2api();
-            let api_voice_activity_detection = voice_activity_detection.wire2api();
+            let api_voice_activity_detection =
+                voice_activity_detection.wire2api();
             let api_ice_restart = ice_restart.wire2api();
             let api_use_rtp_mux = use_rtp_mux.wire2api();
             move |task_callback| {
@@ -95,7 +99,8 @@ pub extern "C" fn wire_create_answer(
         },
         move || {
             let api_peer_id = peer_id.wire2api();
-            let api_voice_activity_detection = voice_activity_detection.wire2api();
+            let api_voice_activity_detection =
+                voice_activity_detection.wire2api();
             let api_ice_restart = ice_restart.wire2api();
             let api_use_rtp_mux = use_rtp_mux.wire2api();
             move |task_callback| {
@@ -127,7 +132,9 @@ pub extern "C" fn wire_set_local_description(
             let api_peer_id = peer_id.wire2api();
             let api_kind = kind.wire2api();
             let api_sdp = sdp.wire2api();
-            move |task_callback| set_local_description(api_peer_id, api_kind, api_sdp)
+            move |task_callback| {
+                set_local_description(api_peer_id, api_kind, api_sdp)
+            }
         },
     )
 }
@@ -149,13 +156,20 @@ pub extern "C" fn wire_set_remote_description(
             let api_peer_id = peer_id.wire2api();
             let api_kind = kind.wire2api();
             let api_sdp = sdp.wire2api();
-            move |task_callback| set_remote_description(api_peer_id, api_kind, api_sdp)
+            move |task_callback| {
+                set_remote_description(api_peer_id, api_kind, api_sdp)
+            }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_add_transceiver(port_: i64, peer_id: u64, media_type: i32, direction: i32) {
+pub extern "C" fn wire_add_transceiver(
+    port_: i64,
+    peer_id: u64,
+    media_type: i32,
+    direction: i32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "add_transceiver",
@@ -166,7 +180,9 @@ pub extern "C" fn wire_add_transceiver(port_: i64, peer_id: u64, media_type: i32
             let api_peer_id = peer_id.wire2api();
             let api_media_type = media_type.wire2api();
             let api_direction = direction.wire2api();
-            move |task_callback| add_transceiver(api_peer_id, api_media_type, api_direction)
+            move |task_callback| {
+                add_transceiver(api_peer_id, api_media_type, api_direction)
+            }
         },
     )
 }
@@ -204,14 +220,22 @@ pub extern "C" fn wire_set_transceiver_direction(
             let api_transceiver_index = transceiver_index.wire2api();
             let api_direction = direction.wire2api();
             move |task_callback| {
-                set_transceiver_direction(api_peer_id, api_transceiver_index, api_direction)
+                set_transceiver_direction(
+                    api_peer_id,
+                    api_transceiver_index,
+                    api_direction,
+                )
             }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_transceiver_mid(port_: i64, peer_id: u64, transceiver_index: u32) {
+pub extern "C" fn wire_get_transceiver_mid(
+    port_: i64,
+    peer_id: u64,
+    transceiver_index: u32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_transceiver_mid",
@@ -221,13 +245,19 @@ pub extern "C" fn wire_get_transceiver_mid(port_: i64, peer_id: u64, transceiver
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| get_transceiver_mid(api_peer_id, api_transceiver_index)
+            move |task_callback| {
+                get_transceiver_mid(api_peer_id, api_transceiver_index)
+            }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_transceiver_direction(port_: i64, peer_id: u64, transceiver_index: u32) {
+pub extern "C" fn wire_get_transceiver_direction(
+    port_: i64,
+    peer_id: u64,
+    transceiver_index: u32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_transceiver_direction",
@@ -237,13 +267,19 @@ pub extern "C" fn wire_get_transceiver_direction(port_: i64, peer_id: u64, trans
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| get_transceiver_direction(api_peer_id, api_transceiver_index)
+            move |task_callback| {
+                get_transceiver_direction(api_peer_id, api_transceiver_index)
+            }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_stop_transceiver(port_: i64, peer_id: u64, transceiver_index: u32) {
+pub extern "C" fn wire_stop_transceiver(
+    port_: i64,
+    peer_id: u64,
+    transceiver_index: u32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "stop_transceiver",
@@ -253,7 +289,9 @@ pub extern "C" fn wire_stop_transceiver(port_: i64, peer_id: u64, transceiver_in
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| stop_transceiver(api_peer_id, api_transceiver_index)
+            move |task_callback| {
+                stop_transceiver(api_peer_id, api_transceiver_index)
+            }
         },
     )
 }
@@ -276,7 +314,11 @@ pub extern "C" fn wire_sender_replace_track(
             let api_transceiver_index = transceiver_index.wire2api();
             let api_track_id = track_id.wire2api();
             move |task_callback| {
-                sender_replace_track(api_peer_id, api_transceiver_index, api_track_id)
+                sender_replace_track(
+                    api_peer_id,
+                    api_transceiver_index,
+                    api_track_id,
+                )
             }
         },
     )
@@ -302,7 +344,12 @@ pub extern "C" fn wire_add_ice_candidate(
             let api_sdp_mid = sdp_mid.wire2api();
             let api_sdp_mline_index = sdp_mline_index.wire2api();
             move |task_callback| {
-                add_ice_candidate(api_peer_id, api_candidate, api_sdp_mid, api_sdp_mline_index)
+                add_ice_candidate(
+                    api_peer_id,
+                    api_candidate,
+                    api_sdp_mid,
+                    api_sdp_mline_index,
+                )
             }
         },
     )
@@ -339,7 +386,10 @@ pub extern "C" fn wire_dispose_peer_connection(port_: i64, peer_id: u64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_media(port_: i64, constraints: *mut wire_MediaStreamConstraints) {
+pub extern "C" fn wire_get_media(
+    port_: i64,
+    constraints: *mut wire_MediaStreamConstraints,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_media",
@@ -354,7 +404,10 @@ pub extern "C" fn wire_get_media(port_: i64, constraints: *mut wire_MediaStreamC
 }
 
 #[no_mangle]
-pub extern "C" fn wire_set_audio_playout_device(port_: i64, device_id: *mut wire_uint_8_list) {
+pub extern "C" fn wire_set_audio_playout_device(
+    port_: i64,
+    device_id: *mut wire_uint_8_list,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "set_audio_playout_device",
@@ -369,7 +422,11 @@ pub extern "C" fn wire_set_audio_playout_device(port_: i64, device_id: *mut wire
 }
 
 #[no_mangle]
-pub extern "C" fn wire_dispose_track(port_: i64, track_id: *mut wire_uint_8_list) {
+pub extern "C" fn wire_dispose_track(
+    port_: i64,
+    track_id: *mut wire_uint_8_list,
+    kind: i32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "dispose_track",
@@ -378,7 +435,8 @@ pub extern "C" fn wire_dispose_track(port_: i64, track_id: *mut wire_uint_8_list
         },
         move || {
             let api_track_id = track_id.wire2api();
-            move |task_callback| Ok(dispose_track(api_track_id))
+            let api_kind = kind.wire2api();
+            move |task_callback| Ok(dispose_track(api_track_id, api_kind))
         },
     )
 }
@@ -387,6 +445,7 @@ pub extern "C" fn wire_dispose_track(port_: i64, track_id: *mut wire_uint_8_list
 pub extern "C" fn wire_set_track_enabled(
     port_: i64,
     track_id: *mut wire_uint_8_list,
+    kind: i32,
     enabled: bool,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
@@ -397,14 +456,21 @@ pub extern "C" fn wire_set_track_enabled(
         },
         move || {
             let api_track_id = track_id.wire2api();
+            let api_kind = kind.wire2api();
             let api_enabled = enabled.wire2api();
-            move |task_callback| set_track_enabled(api_track_id, api_enabled)
+            move |task_callback| {
+                set_track_enabled(api_track_id, api_kind, api_enabled)
+            }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_clone_track(port_: i64, track_id: *mut wire_uint_8_list) {
+pub extern "C" fn wire_clone_track(
+    port_: i64,
+    track_id: *mut wire_uint_8_list,
+    kind: i32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "clone_track",
@@ -413,13 +479,18 @@ pub extern "C" fn wire_clone_track(port_: i64, track_id: *mut wire_uint_8_list) 
         },
         move || {
             let api_track_id = track_id.wire2api();
-            move |task_callback| clone_track(api_track_id)
+            let api_kind = kind.wire2api();
+            move |task_callback| clone_track(api_track_id, api_kind)
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_register_track_observer(port_: i64, track_id: *mut wire_uint_8_list) {
+pub extern "C" fn wire_register_track_observer(
+    port_: i64,
+    track_id: *mut wire_uint_8_list,
+    kind: i32,
+) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "register_track_observer",
@@ -428,7 +499,14 @@ pub extern "C" fn wire_register_track_observer(port_: i64, track_id: *mut wire_u
         },
         move || {
             let api_track_id = track_id.wire2api();
-            move |task_callback| register_track_observer(task_callback.stream_sink(), api_track_id)
+            let api_kind = kind.wire2api();
+            move |task_callback| {
+                register_track_observer(
+                    task_callback.stream_sink(),
+                    api_track_id,
+                    api_kind,
+                )
+            }
         },
     )
 }
@@ -441,7 +519,11 @@ pub extern "C" fn wire_set_on_device_changed(port_: i64) {
             port: Some(port_),
             mode: FfiCallMode::Stream,
         },
-        move || move |task_callback| set_on_device_changed(task_callback.stream_sink()),
+        move || {
+            move |task_callback| {
+                set_on_device_changed(task_callback.stream_sink())
+            }
+        },
     )
 }
 
@@ -462,13 +544,17 @@ pub extern "C" fn wire_create_video_sink(
             let api_sink_id = sink_id.wire2api();
             let api_track_id = track_id.wire2api();
             let api_callback_ptr = callback_ptr.wire2api();
-            move |task_callback| create_video_sink(api_sink_id, api_track_id, api_callback_ptr)
+            move |task_callback| {
+                create_video_sink(api_sink_id, api_track_id, api_callback_ptr)
+            }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_dispose_video_sink(sink_id: i64) -> support::WireSyncReturnStruct {
+pub extern "C" fn wire_dispose_video_sink(
+    sink_id: i64,
+) -> support::WireSyncReturnStruct {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
         WrapInfo {
             debug_name: "dispose_video_sink",
@@ -553,36 +639,48 @@ pub struct wire_VideoConstraints {
 #[no_mangle]
 pub extern "C" fn new_StringList(len: i32) -> *mut wire_StringList {
     let wrap = wire_StringList {
-        ptr: support::new_leak_vec_ptr(<*mut wire_uint_8_list>::new_with_null_ptr(), len),
+        ptr: support::new_leak_vec_ptr(
+            <*mut wire_uint_8_list>::new_with_null_ptr(),
+            len,
+        ),
         len,
     };
     support::new_leak_box_ptr(wrap)
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_audio_constraints() -> *mut wire_AudioConstraints {
+pub extern "C" fn new_box_autoadd_audio_constraints(
+) -> *mut wire_AudioConstraints {
     support::new_leak_box_ptr(wire_AudioConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_media_stream_constraints() -> *mut wire_MediaStreamConstraints {
+pub extern "C" fn new_box_autoadd_media_stream_constraints(
+) -> *mut wire_MediaStreamConstraints {
     support::new_leak_box_ptr(wire_MediaStreamConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_rtc_configuration() -> *mut wire_RtcConfiguration {
+pub extern "C" fn new_box_autoadd_rtc_configuration(
+) -> *mut wire_RtcConfiguration {
     support::new_leak_box_ptr(wire_RtcConfiguration::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_video_constraints() -> *mut wire_VideoConstraints {
+pub extern "C" fn new_box_autoadd_video_constraints(
+) -> *mut wire_VideoConstraints {
     support::new_leak_box_ptr(wire_VideoConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_list_rtc_ice_server(len: i32) -> *mut wire_list_rtc_ice_server {
+pub extern "C" fn new_list_rtc_ice_server(
+    len: i32,
+) -> *mut wire_list_rtc_ice_server {
     let wrap = wire_list_rtc_ice_server {
-        ptr: support::new_leak_vec_ptr(<wire_RtcIceServer>::new_with_null_ptr(), len),
+        ptr: support::new_leak_vec_ptr(
+            <wire_RtcIceServer>::new_with_null_ptr(),
+            len,
+        ),
         len,
     };
     support::new_leak_box_ptr(wrap)
@@ -705,7 +803,9 @@ impl Wire2Api<IceTransportsType> for i32 {
             1 => IceTransportsType::Relay,
             2 => IceTransportsType::NoHost,
             3 => IceTransportsType::None,
-            _ => unreachable!("Invalid variant for IceTransportsType: {}", self),
+            _ => {
+                unreachable!("Invalid variant for IceTransportsType: {}", self)
+            }
         }
     }
 }
@@ -767,7 +867,10 @@ impl Wire2Api<RtpTransceiverDirection> for i32 {
             2 => RtpTransceiverDirection::RecvOnly,
             3 => RtpTransceiverDirection::Inactive,
             4 => RtpTransceiverDirection::Stopped,
-            _ => unreachable!("Invalid variant for RtpTransceiverDirection: {}", self),
+            _ => unreachable!(
+                "Invalid variant for RtpTransceiverDirection: {}",
+                self
+            ),
         }
     }
 }
@@ -972,7 +1075,9 @@ impl support::IntoDart for PeerConnectionEvent {
                 sdp_mline_index.into_dart(),
                 candidate.into_dart(),
             ],
-            Self::IceGatheringStateChange(field0) => vec![2.into_dart(), field0.into_dart()],
+            Self::IceGatheringStateChange(field0) => {
+                vec![2.into_dart(), field0.into_dart()]
+            }
             Self::IceCandidateError {
                 address,
                 port,
@@ -988,9 +1093,15 @@ impl support::IntoDart for PeerConnectionEvent {
                 error_text.into_dart(),
             ],
             Self::NegotiationNeeded => vec![4.into_dart()],
-            Self::SignallingChange(field0) => vec![5.into_dart(), field0.into_dart()],
-            Self::IceConnectionStateChange(field0) => vec![6.into_dart(), field0.into_dart()],
-            Self::ConnectionStateChange(field0) => vec![7.into_dart(), field0.into_dart()],
+            Self::SignallingChange(field0) => {
+                vec![5.into_dart(), field0.into_dart()]
+            }
+            Self::IceConnectionStateChange(field0) => {
+                vec![6.into_dart(), field0.into_dart()]
+            }
+            Self::ConnectionStateChange(field0) => {
+                vec![7.into_dart(), field0.into_dart()]
+            }
             Self::Track(field0) => vec![8.into_dart(), field0.into_dart()],
         }
         .into_dart()
@@ -1095,7 +1206,9 @@ support::lazy_static! {
 // Section: sync execution mode utility
 
 #[no_mangle]
-pub extern "C" fn free_WireSyncReturnStruct(val: support::WireSyncReturnStruct) {
+pub extern "C" fn free_WireSyncReturnStruct(
+    val: support::WireSyncReturnStruct,
+) {
     unsafe {
         let _ = support::vec_from_leak_ptr(val.ptr, val.len);
     }

--- a/crates/native/src/bridge_generated.rs
+++ b/crates/native/src/bridge_generated.rs
@@ -42,10 +42,7 @@ pub extern "C" fn wire_create_peer_connection(
         move || {
             let api_configuration = configuration.wire2api();
             move |task_callback| {
-                create_peer_connection(
-                    task_callback.stream_sink(),
-                    api_configuration,
-                )
+                create_peer_connection(task_callback.stream_sink(), api_configuration)
             }
         },
     )
@@ -67,8 +64,7 @@ pub extern "C" fn wire_create_offer(
         },
         move || {
             let api_peer_id = peer_id.wire2api();
-            let api_voice_activity_detection =
-                voice_activity_detection.wire2api();
+            let api_voice_activity_detection = voice_activity_detection.wire2api();
             let api_ice_restart = ice_restart.wire2api();
             let api_use_rtp_mux = use_rtp_mux.wire2api();
             move |task_callback| {
@@ -99,8 +95,7 @@ pub extern "C" fn wire_create_answer(
         },
         move || {
             let api_peer_id = peer_id.wire2api();
-            let api_voice_activity_detection =
-                voice_activity_detection.wire2api();
+            let api_voice_activity_detection = voice_activity_detection.wire2api();
             let api_ice_restart = ice_restart.wire2api();
             let api_use_rtp_mux = use_rtp_mux.wire2api();
             move |task_callback| {
@@ -132,9 +127,7 @@ pub extern "C" fn wire_set_local_description(
             let api_peer_id = peer_id.wire2api();
             let api_kind = kind.wire2api();
             let api_sdp = sdp.wire2api();
-            move |task_callback| {
-                set_local_description(api_peer_id, api_kind, api_sdp)
-            }
+            move |task_callback| set_local_description(api_peer_id, api_kind, api_sdp)
         },
     )
 }
@@ -156,20 +149,13 @@ pub extern "C" fn wire_set_remote_description(
             let api_peer_id = peer_id.wire2api();
             let api_kind = kind.wire2api();
             let api_sdp = sdp.wire2api();
-            move |task_callback| {
-                set_remote_description(api_peer_id, api_kind, api_sdp)
-            }
+            move |task_callback| set_remote_description(api_peer_id, api_kind, api_sdp)
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_add_transceiver(
-    port_: i64,
-    peer_id: u64,
-    media_type: i32,
-    direction: i32,
-) {
+pub extern "C" fn wire_add_transceiver(port_: i64, peer_id: u64, media_type: i32, direction: i32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "add_transceiver",
@@ -180,9 +166,7 @@ pub extern "C" fn wire_add_transceiver(
             let api_peer_id = peer_id.wire2api();
             let api_media_type = media_type.wire2api();
             let api_direction = direction.wire2api();
-            move |task_callback| {
-                add_transceiver(api_peer_id, api_media_type, api_direction)
-            }
+            move |task_callback| add_transceiver(api_peer_id, api_media_type, api_direction)
         },
     )
 }
@@ -220,22 +204,14 @@ pub extern "C" fn wire_set_transceiver_direction(
             let api_transceiver_index = transceiver_index.wire2api();
             let api_direction = direction.wire2api();
             move |task_callback| {
-                set_transceiver_direction(
-                    api_peer_id,
-                    api_transceiver_index,
-                    api_direction,
-                )
+                set_transceiver_direction(api_peer_id, api_transceiver_index, api_direction)
             }
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_transceiver_mid(
-    port_: i64,
-    peer_id: u64,
-    transceiver_index: u32,
-) {
+pub extern "C" fn wire_get_transceiver_mid(port_: i64, peer_id: u64, transceiver_index: u32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_transceiver_mid",
@@ -245,19 +221,13 @@ pub extern "C" fn wire_get_transceiver_mid(
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| {
-                get_transceiver_mid(api_peer_id, api_transceiver_index)
-            }
+            move |task_callback| get_transceiver_mid(api_peer_id, api_transceiver_index)
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_transceiver_direction(
-    port_: i64,
-    peer_id: u64,
-    transceiver_index: u32,
-) {
+pub extern "C" fn wire_get_transceiver_direction(port_: i64, peer_id: u64, transceiver_index: u32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_transceiver_direction",
@@ -267,19 +237,13 @@ pub extern "C" fn wire_get_transceiver_direction(
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| {
-                get_transceiver_direction(api_peer_id, api_transceiver_index)
-            }
+            move |task_callback| get_transceiver_direction(api_peer_id, api_transceiver_index)
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_stop_transceiver(
-    port_: i64,
-    peer_id: u64,
-    transceiver_index: u32,
-) {
+pub extern "C" fn wire_stop_transceiver(port_: i64, peer_id: u64, transceiver_index: u32) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "stop_transceiver",
@@ -289,9 +253,7 @@ pub extern "C" fn wire_stop_transceiver(
         move || {
             let api_peer_id = peer_id.wire2api();
             let api_transceiver_index = transceiver_index.wire2api();
-            move |task_callback| {
-                stop_transceiver(api_peer_id, api_transceiver_index)
-            }
+            move |task_callback| stop_transceiver(api_peer_id, api_transceiver_index)
         },
     )
 }
@@ -301,7 +263,7 @@ pub extern "C" fn wire_sender_replace_track(
     port_: i64,
     peer_id: u64,
     transceiver_index: u32,
-    track_id: *mut u64,
+    track_id: *mut wire_uint_8_list,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
@@ -314,11 +276,7 @@ pub extern "C" fn wire_sender_replace_track(
             let api_transceiver_index = transceiver_index.wire2api();
             let api_track_id = track_id.wire2api();
             move |task_callback| {
-                sender_replace_track(
-                    api_peer_id,
-                    api_transceiver_index,
-                    api_track_id,
-                )
+                sender_replace_track(api_peer_id, api_transceiver_index, api_track_id)
             }
         },
     )
@@ -344,12 +302,7 @@ pub extern "C" fn wire_add_ice_candidate(
             let api_sdp_mid = sdp_mid.wire2api();
             let api_sdp_mline_index = sdp_mline_index.wire2api();
             move |task_callback| {
-                add_ice_candidate(
-                    api_peer_id,
-                    api_candidate,
-                    api_sdp_mid,
-                    api_sdp_mline_index,
-                )
+                add_ice_candidate(api_peer_id, api_candidate, api_sdp_mid, api_sdp_mline_index)
             }
         },
     )
@@ -386,10 +339,7 @@ pub extern "C" fn wire_dispose_peer_connection(port_: i64, peer_id: u64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_get_media(
-    port_: i64,
-    constraints: *mut wire_MediaStreamConstraints,
-) {
+pub extern "C" fn wire_get_media(port_: i64, constraints: *mut wire_MediaStreamConstraints) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "get_media",
@@ -404,10 +354,7 @@ pub extern "C" fn wire_get_media(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_set_audio_playout_device(
-    port_: i64,
-    device_id: *mut wire_uint_8_list,
-) {
+pub extern "C" fn wire_set_audio_playout_device(port_: i64, device_id: *mut wire_uint_8_list) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "set_audio_playout_device",
@@ -422,7 +369,7 @@ pub extern "C" fn wire_set_audio_playout_device(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_dispose_track(port_: i64, track_id: u64) {
+pub extern "C" fn wire_dispose_track(port_: i64, track_id: *mut wire_uint_8_list) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "dispose_track",
@@ -439,7 +386,7 @@ pub extern "C" fn wire_dispose_track(port_: i64, track_id: u64) {
 #[no_mangle]
 pub extern "C" fn wire_set_track_enabled(
     port_: i64,
-    track_id: u64,
+    track_id: *mut wire_uint_8_list,
     enabled: bool,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
@@ -457,7 +404,7 @@ pub extern "C" fn wire_set_track_enabled(
 }
 
 #[no_mangle]
-pub extern "C" fn wire_clone_track(port_: i64, track_id: u64) {
+pub extern "C" fn wire_clone_track(port_: i64, track_id: *mut wire_uint_8_list) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "clone_track",
@@ -472,7 +419,7 @@ pub extern "C" fn wire_clone_track(port_: i64, track_id: u64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_register_track_observer(port_: i64, track_id: u64) {
+pub extern "C" fn wire_register_track_observer(port_: i64, track_id: *mut wire_uint_8_list) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
         WrapInfo {
             debug_name: "register_track_observer",
@@ -481,12 +428,7 @@ pub extern "C" fn wire_register_track_observer(port_: i64, track_id: u64) {
         },
         move || {
             let api_track_id = track_id.wire2api();
-            move |task_callback| {
-                register_track_observer(
-                    task_callback.stream_sink(),
-                    api_track_id,
-                )
-            }
+            move |task_callback| register_track_observer(task_callback.stream_sink(), api_track_id)
         },
     )
 }
@@ -499,11 +441,7 @@ pub extern "C" fn wire_set_on_device_changed(port_: i64) {
             port: Some(port_),
             mode: FfiCallMode::Stream,
         },
-        move || {
-            move |task_callback| {
-                set_on_device_changed(task_callback.stream_sink())
-            }
-        },
+        move || move |task_callback| set_on_device_changed(task_callback.stream_sink()),
     )
 }
 
@@ -511,7 +449,7 @@ pub extern "C" fn wire_set_on_device_changed(port_: i64) {
 pub extern "C" fn wire_create_video_sink(
     port_: i64,
     sink_id: i64,
-    track_id: u64,
+    track_id: *mut wire_uint_8_list,
     callback_ptr: u64,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap(
@@ -524,17 +462,13 @@ pub extern "C" fn wire_create_video_sink(
             let api_sink_id = sink_id.wire2api();
             let api_track_id = track_id.wire2api();
             let api_callback_ptr = callback_ptr.wire2api();
-            move |task_callback| {
-                create_video_sink(api_sink_id, api_track_id, api_callback_ptr)
-            }
+            move |task_callback| create_video_sink(api_sink_id, api_track_id, api_callback_ptr)
         },
     )
 }
 
 #[no_mangle]
-pub extern "C" fn wire_dispose_video_sink(
-    sink_id: i64,
-) -> support::WireSyncReturnStruct {
+pub extern "C" fn wire_dispose_video_sink(sink_id: i64) -> support::WireSyncReturnStruct {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
         WrapInfo {
             debug_name: "dispose_video_sink",
@@ -619,53 +553,36 @@ pub struct wire_VideoConstraints {
 #[no_mangle]
 pub extern "C" fn new_StringList(len: i32) -> *mut wire_StringList {
     let wrap = wire_StringList {
-        ptr: support::new_leak_vec_ptr(
-            <*mut wire_uint_8_list>::new_with_null_ptr(),
-            len,
-        ),
+        ptr: support::new_leak_vec_ptr(<*mut wire_uint_8_list>::new_with_null_ptr(), len),
         len,
     };
     support::new_leak_box_ptr(wrap)
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_audio_constraints(
-) -> *mut wire_AudioConstraints {
+pub extern "C" fn new_box_autoadd_audio_constraints() -> *mut wire_AudioConstraints {
     support::new_leak_box_ptr(wire_AudioConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_media_stream_constraints(
-) -> *mut wire_MediaStreamConstraints {
+pub extern "C" fn new_box_autoadd_media_stream_constraints() -> *mut wire_MediaStreamConstraints {
     support::new_leak_box_ptr(wire_MediaStreamConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_rtc_configuration(
-) -> *mut wire_RtcConfiguration {
+pub extern "C" fn new_box_autoadd_rtc_configuration() -> *mut wire_RtcConfiguration {
     support::new_leak_box_ptr(wire_RtcConfiguration::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_u64(value: u64) -> *mut u64 {
-    support::new_leak_box_ptr(value)
-}
-
-#[no_mangle]
-pub extern "C" fn new_box_autoadd_video_constraints(
-) -> *mut wire_VideoConstraints {
+pub extern "C" fn new_box_autoadd_video_constraints() -> *mut wire_VideoConstraints {
     support::new_leak_box_ptr(wire_VideoConstraints::new_with_null_ptr())
 }
 
 #[no_mangle]
-pub extern "C" fn new_list_rtc_ice_server(
-    len: i32,
-) -> *mut wire_list_rtc_ice_server {
+pub extern "C" fn new_list_rtc_ice_server(len: i32) -> *mut wire_list_rtc_ice_server {
     let wrap = wire_list_rtc_ice_server {
-        ptr: support::new_leak_vec_ptr(
-            <wire_RtcIceServer>::new_with_null_ptr(),
-            len,
-        ),
+        ptr: support::new_leak_vec_ptr(<wire_RtcIceServer>::new_with_null_ptr(), len),
         len,
     };
     support::new_leak_box_ptr(wrap)
@@ -751,12 +668,6 @@ impl Wire2Api<RtcConfiguration> for *mut wire_RtcConfiguration {
     }
 }
 
-impl Wire2Api<u64> for *mut u64 {
-    fn wire2api(self) -> u64 {
-        unsafe { *support::box_from_leak_ptr(self) }
-    }
-}
-
 impl Wire2Api<VideoConstraints> for *mut wire_VideoConstraints {
     fn wire2api(self) -> VideoConstraints {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
@@ -794,9 +705,7 @@ impl Wire2Api<IceTransportsType> for i32 {
             1 => IceTransportsType::Relay,
             2 => IceTransportsType::NoHost,
             3 => IceTransportsType::None,
-            _ => {
-                unreachable!("Invalid variant for IceTransportsType: {}", self)
-            }
+            _ => unreachable!("Invalid variant for IceTransportsType: {}", self),
         }
     }
 }
@@ -858,10 +767,7 @@ impl Wire2Api<RtpTransceiverDirection> for i32 {
             2 => RtpTransceiverDirection::RecvOnly,
             3 => RtpTransceiverDirection::Inactive,
             4 => RtpTransceiverDirection::Stopped,
-            _ => unreachable!(
-                "Invalid variant for RtpTransceiverDirection: {}",
-                self
-            ),
+            _ => unreachable!("Invalid variant for RtpTransceiverDirection: {}", self),
         }
     }
 }
@@ -1066,9 +972,7 @@ impl support::IntoDart for PeerConnectionEvent {
                 sdp_mline_index.into_dart(),
                 candidate.into_dart(),
             ],
-            Self::IceGatheringStateChange(field0) => {
-                vec![2.into_dart(), field0.into_dart()]
-            }
+            Self::IceGatheringStateChange(field0) => vec![2.into_dart(), field0.into_dart()],
             Self::IceCandidateError {
                 address,
                 port,
@@ -1084,15 +988,9 @@ impl support::IntoDart for PeerConnectionEvent {
                 error_text.into_dart(),
             ],
             Self::NegotiationNeeded => vec![4.into_dart()],
-            Self::SignallingChange(field0) => {
-                vec![5.into_dart(), field0.into_dart()]
-            }
-            Self::IceConnectionStateChange(field0) => {
-                vec![6.into_dart(), field0.into_dart()]
-            }
-            Self::ConnectionStateChange(field0) => {
-                vec![7.into_dart(), field0.into_dart()]
-            }
+            Self::SignallingChange(field0) => vec![5.into_dart(), field0.into_dart()],
+            Self::IceConnectionStateChange(field0) => vec![6.into_dart(), field0.into_dart()],
+            Self::ConnectionStateChange(field0) => vec![7.into_dart(), field0.into_dart()],
             Self::Track(field0) => vec![8.into_dart(), field0.into_dart()],
         }
         .into_dart()
@@ -1197,9 +1095,7 @@ support::lazy_static! {
 // Section: sync execution mode utility
 
 #[no_mangle]
-pub extern "C" fn free_WireSyncReturnStruct(
-    val: support::WireSyncReturnStruct,
-) {
+pub extern "C" fn free_WireSyncReturnStruct(val: support::WireSyncReturnStruct) {
     unsafe {
         let _ = support::vec_from_leak_ptr(val.ptr, val.len);
     }

--- a/crates/native/src/lib.rs
+++ b/crates/native/src/lib.rs
@@ -93,7 +93,7 @@ impl Webrtc {
                 None,
                 Some(&worker_thread),
                 Some(&signaling_thread),
-                Some(audio_device_module.as_ref()),
+                Some(&audio_device_module.inner),
             )?;
 
         let video_device_info = sys::VideoDeviceInfo::create()?;

--- a/crates/native/src/lib.rs
+++ b/crates/native/src/lib.rs
@@ -93,7 +93,7 @@ impl Webrtc {
                 None,
                 Some(&worker_thread),
                 Some(&signaling_thread),
-                Some(&audio_device_module.inner),
+                Some(audio_device_module.as_ref()),
             )?;
 
         let video_device_info = sys::VideoDeviceInfo::create()?;

--- a/crates/native/src/pc.rs
+++ b/crates/native/src/pc.rs
@@ -853,8 +853,12 @@ impl sys::PeerConnectionEventsHandler for PeerConnectionObserver {
     fn on_track(&mut self, transceiver: sys::RtpTransceiverInterface) {
         let track_id = transceiver.receiver().track().id();
 
-        if self.video_tracks.contains_key(&VideoTrackId::from(track_id.clone()))
-            || self.audio_tracks.contains_key(&AudioTrackId::from(track_id))
+        if self
+            .video_tracks
+            .contains_key(&VideoTrackId::from(track_id.clone()))
+            || self
+                .audio_tracks
+                .contains_key(&AudioTrackId::from(track_id))
         {
             return;
         }

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -344,8 +344,8 @@ impl Webrtc {
 
                         if transceivers.is_empty() {
                             bail!(
-                                "No `transceiver` has been found with \
-                                    mid `{mid}`"
+                                "No `transceiver` has been found with mid \
+                                 `{mid}`",
                             );
                         }
 
@@ -393,8 +393,8 @@ impl Webrtc {
 
                         if transceivers.is_empty() {
                             bail!(
-                                "No `transceiver` has been found with \
-                                    mid `{mid}`"
+                                "No `transceiver` has been found with mid \
+                                 `{mid}`",
                             );
                         }
 
@@ -466,11 +466,11 @@ pub struct VideoDeviceId(String);
 pub struct AudioDeviceId(String);
 
 /// ID of a [`VideoTrack`].
-#[derive(Clone, Debug, Display, From, Eq, Hash, PartialEq, Into)]
+#[derive(Clone, Debug, Display, From, Eq, Hash, Into, PartialEq)]
 pub struct VideoTrackId(String);
 
 /// ID of an [`AudioTrack`].
-#[derive(Clone, Debug, Display, From, Eq, Hash, PartialEq, Into)]
+#[derive(Clone, Debug, Display, From, Eq, Hash, Into, PartialEq)]
 pub struct AudioTrackId(String);
 
 /// Label identifying a video track source.

--- a/crates/native/src/video_sink.rs
+++ b/crates/native/src/video_sink.rs
@@ -10,7 +10,7 @@ impl Webrtc {
     pub fn create_video_sink(
         &mut self,
         sink_id: i64,
-        track_id: u64,
+        track_id: String,
         handler: UniquePtr<cpp_api::OnFrameCallbackInterface>,
     ) -> anyhow::Result<()> {
         self.dispose_video_sink(sink_id);
@@ -21,7 +21,7 @@ impl Webrtc {
             inner: sys::VideoSinkInterface::create_forwarding(Box::new(
                 OnFrameCallback(handler),
             )),
-            track_id,
+            track_id: track_id.clone(),
         };
 
         let mut track = self

--- a/lib/src/api/bridge.g.dart
+++ b/lib/src/api/bridge.g.dart
@@ -4,13 +4,13 @@
 // ignore_for_file: non_constant_identifier_names, unused_element, duplicate_ignore, directives_ordering, curly_braces_in_flow_control_structures, unnecessary_lambdas, slash_for_doc_comments, prefer_const_literals_to_create_immutables, implicit_dynamic_list_literal, duplicate_import, unused_import, prefer_single_quotes
 
 import 'dart:convert';
-import 'dart:convert';
-import 'dart:ffi' as ffi;
 import 'dart:typed_data';
-import 'dart:typed_data';
-
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'dart:ffi' as ffi;
 
 part 'bridge.g.freezed.dart';
 
@@ -100,7 +100,7 @@ abstract class FlutterWebrtcNative {
   Future<void> senderReplaceTrack(
       {required int peerId,
       required int transceiverIndex,
-      int? trackId,
+      String? trackId,
       dynamic hint});
 
   /// Adds the new ICE `candidate` to the given [`PeerConnection`].
@@ -126,20 +126,20 @@ abstract class FlutterWebrtcNative {
   Future<void> setAudioPlayoutDevice({required String deviceId, dynamic hint});
 
   /// Disposes the specified [`MediaStreamTrack`].
-  Future<void> disposeTrack({required int trackId, dynamic hint});
+  Future<void> disposeTrack({required String trackId, dynamic hint});
 
   /// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#track-enabled
   Future<void> setTrackEnabled(
-      {required int trackId, required bool enabled, dynamic hint});
+      {required String trackId, required bool enabled, dynamic hint});
 
   /// Clones the specified [`MediaStreamTrack`].
-  Future<MediaStreamTrack> cloneTrack({required int trackId, dynamic hint});
+  Future<MediaStreamTrack> cloneTrack({required String trackId, dynamic hint});
 
   /// Registers an observer to the [`MediaStreamTrack`] events.
   Stream<TrackEvent> registerTrackObserver(
-      {required int trackId, dynamic hint});
+      {required String trackId, dynamic hint});
 
   /// Sets the provided [`OnDeviceChangeCallback`] as the callback to be called
   /// whenever a set of available media devices changes.
@@ -154,7 +154,7 @@ abstract class FlutterWebrtcNative {
   /// an [`OnFrameCallbackInterface`].
   Future<void> createVideoSink(
       {required int sinkId,
-      required int trackId,
+      required String trackId,
       required int callbackPtr,
       dynamic hint});
 
@@ -347,7 +347,7 @@ class MediaStreamConstraints {
 /// as well.
 class MediaStreamTrack {
   /// Unique identifier (GUID) of this [`MediaStreamTrack`].
-  final int id;
+  final String id;
 
   /// Label identifying the track source, as in "internal microphone".
   final String deviceId;
@@ -1015,14 +1015,14 @@ class FlutterWebrtcNativeImpl
   Future<void> senderReplaceTrack(
           {required int peerId,
           required int transceiverIndex,
-          int? trackId,
+          String? trackId,
           dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_sender_replace_track(
             port_,
             _api2wire_u64(peerId),
             _api2wire_u32(transceiverIndex),
-            _api2wire_opt_box_autoadd_u64(trackId)),
+            _api2wire_opt_String(trackId)),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "sender_replace_track",
@@ -1108,10 +1108,10 @@ class FlutterWebrtcNativeImpl
         hint: hint,
       ));
 
-  Future<void> disposeTrack({required int trackId, dynamic hint}) =>
+  Future<void> disposeTrack({required String trackId, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) =>
-            inner.wire_dispose_track(port_, _api2wire_u64(trackId)),
+            inner.wire_dispose_track(port_, _api2wire_String(trackId)),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "dispose_track",
@@ -1122,10 +1122,10 @@ class FlutterWebrtcNativeImpl
       ));
 
   Future<void> setTrackEnabled(
-          {required int trackId, required bool enabled, dynamic hint}) =>
+          {required String trackId, required bool enabled, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_set_track_enabled(
-            port_, _api2wire_u64(trackId), enabled),
+            port_, _api2wire_String(trackId), enabled),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "set_track_enabled",
@@ -1135,10 +1135,11 @@ class FlutterWebrtcNativeImpl
         hint: hint,
       ));
 
-  Future<MediaStreamTrack> cloneTrack({required int trackId, dynamic hint}) =>
+  Future<MediaStreamTrack> cloneTrack(
+          {required String trackId, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) =>
-            inner.wire_clone_track(port_, _api2wire_u64(trackId)),
+            inner.wire_clone_track(port_, _api2wire_String(trackId)),
         parseSuccessData: _wire2api_media_stream_track,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "clone_track",
@@ -1149,10 +1150,10 @@ class FlutterWebrtcNativeImpl
       ));
 
   Stream<TrackEvent> registerTrackObserver(
-          {required int trackId, dynamic hint}) =>
+          {required String trackId, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_register_track_observer(port_, _api2wire_u64(trackId)),
+        callFfi: (port_) => inner.wire_register_track_observer(
+            port_, _api2wire_String(trackId)),
         parseSuccessData: _wire2api_track_event,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "register_track_observer",
@@ -1176,14 +1177,14 @@ class FlutterWebrtcNativeImpl
 
   Future<void> createVideoSink(
           {required int sinkId,
-          required int trackId,
+          required String trackId,
           required int callbackPtr,
           dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_create_video_sink(
             port_,
             _api2wire_i64(sinkId),
-            _api2wire_u64(trackId),
+            _api2wire_String(trackId),
             _api2wire_u64(callbackPtr)),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
@@ -1244,10 +1245,6 @@ class FlutterWebrtcNativeImpl
     return ptr;
   }
 
-  ffi.Pointer<ffi.Uint64> _api2wire_box_autoadd_u64(int raw) {
-    return inner.new_box_autoadd_u64(raw);
-  }
-
   ffi.Pointer<wire_VideoConstraints> _api2wire_box_autoadd_video_constraints(
       VideoConstraints raw) {
     final ptr = inner.new_box_autoadd_video_constraints();
@@ -1293,10 +1290,6 @@ class FlutterWebrtcNativeImpl
     return raw == null
         ? ffi.nullptr
         : _api2wire_box_autoadd_audio_constraints(raw);
-  }
-
-  ffi.Pointer<ffi.Uint64> _api2wire_opt_box_autoadd_u64(int? raw) {
-    return raw == null ? ffi.nullptr : _api2wire_box_autoadd_u64(raw);
   }
 
   ffi.Pointer<wire_VideoConstraints>
@@ -1464,7 +1457,7 @@ MediaStreamTrack _wire2api_media_stream_track(dynamic raw) {
   if (arr.length != 4)
     throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
   return MediaStreamTrack(
-    id: _wire2api_u64(arr[0]),
+    id: _wire2api_String(arr[0]),
     deviceId: _wire2api_String(arr[1]),
     kind: _wire2api_media_type(arr[2]),
     enabled: _wire2api_bool(arr[3]),
@@ -1859,7 +1852,7 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
     int port_,
     int peer_id,
     int transceiver_index,
-    ffi.Pointer<ffi.Uint64> track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
   ) {
     return _wire_sender_replace_track(
       port_,
@@ -1872,9 +1865,10 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
   late final _wire_sender_replace_trackPtr = _lookup<
       ffi.NativeFunction<
           ffi.Void Function(ffi.Int64, ffi.Uint64, ffi.Uint32,
-              ffi.Pointer<ffi.Uint64>)>>('wire_sender_replace_track');
-  late final _wire_sender_replace_track = _wire_sender_replace_trackPtr
-      .asFunction<void Function(int, int, int, ffi.Pointer<ffi.Uint64>)>();
+              ffi.Pointer<wire_uint_8_list>)>>('wire_sender_replace_track');
+  late final _wire_sender_replace_track =
+      _wire_sender_replace_trackPtr.asFunction<
+          void Function(int, int, int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_add_ice_candidate(
     int port_,
@@ -1972,7 +1966,7 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
 
   void wire_dispose_track(
     int port_,
-    int track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
   ) {
     return _wire_dispose_track(
       port_,
@@ -1980,15 +1974,16 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_dispose_trackPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint64)>>(
-          'wire_dispose_track');
-  late final _wire_dispose_track =
-      _wire_dispose_trackPtr.asFunction<void Function(int, int)>();
+  late final _wire_dispose_trackPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_dispose_track');
+  late final _wire_dispose_track = _wire_dispose_trackPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_set_track_enabled(
     int port_,
-    int track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
     bool enabled,
   ) {
     return _wire_set_track_enabled(
@@ -2000,14 +1995,14 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
 
   late final _wire_set_track_enabledPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Uint64, ffi.Uint8)>>('wire_set_track_enabled');
-  late final _wire_set_track_enabled =
-      _wire_set_track_enabledPtr.asFunction<void Function(int, int, int)>();
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Uint8)>>('wire_set_track_enabled');
+  late final _wire_set_track_enabled = _wire_set_track_enabledPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   void wire_clone_track(
     int port_,
-    int track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
   ) {
     return _wire_clone_track(
       port_,
@@ -2015,15 +2010,16 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_clone_trackPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint64)>>(
-          'wire_clone_track');
-  late final _wire_clone_track =
-      _wire_clone_trackPtr.asFunction<void Function(int, int)>();
+  late final _wire_clone_trackPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(
+              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_clone_track');
+  late final _wire_clone_track = _wire_clone_trackPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_register_track_observer(
     int port_,
-    int track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
   ) {
     return _wire_register_track_observer(
       port_,
@@ -2031,11 +2027,12 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
     );
   }
 
-  late final _wire_register_track_observerPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint64)>>(
-          'wire_register_track_observer');
-  late final _wire_register_track_observer =
-      _wire_register_track_observerPtr.asFunction<void Function(int, int)>();
+  late final _wire_register_track_observerPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64,
+              ffi.Pointer<wire_uint_8_list>)>>('wire_register_track_observer');
+  late final _wire_register_track_observer = _wire_register_track_observerPtr
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
   void wire_set_on_device_changed(
     int port_,
@@ -2054,7 +2051,7 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
   void wire_create_video_sink(
     int port_,
     int sink_id,
-    int track_id,
+    ffi.Pointer<wire_uint_8_list> track_id,
     int callback_ptr,
   ) {
     return _wire_create_video_sink(
@@ -2067,10 +2064,10 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
 
   late final _wire_create_video_sinkPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Int64, ffi.Uint64,
+          ffi.Void Function(ffi.Int64, ffi.Int64, ffi.Pointer<wire_uint_8_list>,
               ffi.Uint64)>>('wire_create_video_sink');
-  late final _wire_create_video_sink = _wire_create_video_sinkPtr
-      .asFunction<void Function(int, int, int, int)>();
+  late final _wire_create_video_sink = _wire_create_video_sinkPtr.asFunction<
+      void Function(int, int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   WireSyncReturnStruct wire_dispose_video_sink(
     int sink_id,
@@ -2134,20 +2131,6 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
   late final _new_box_autoadd_rtc_configuration =
       _new_box_autoadd_rtc_configurationPtr
           .asFunction<ffi.Pointer<wire_RtcConfiguration> Function()>();
-
-  ffi.Pointer<ffi.Uint64> new_box_autoadd_u64(
-    int value,
-  ) {
-    return _new_box_autoadd_u64(
-      value,
-    );
-  }
-
-  late final _new_box_autoadd_u64Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Uint64> Function(ffi.Uint64)>>(
-          'new_box_autoadd_u64');
-  late final _new_box_autoadd_u64 = _new_box_autoadd_u64Ptr
-      .asFunction<ffi.Pointer<ffi.Uint64> Function(int)>();
 
   ffi.Pointer<wire_VideoConstraints> new_box_autoadd_video_constraints() {
     return _new_box_autoadd_video_constraints();

--- a/lib/src/api/bridge.g.dart
+++ b/lib/src/api/bridge.g.dart
@@ -4,13 +4,13 @@
 // ignore_for_file: non_constant_identifier_names, unused_element, duplicate_ignore, directives_ordering, curly_braces_in_flow_control_structures, unnecessary_lambdas, slash_for_doc_comments, prefer_const_literals_to_create_immutables, implicit_dynamic_list_literal, duplicate_import, unused_import, prefer_single_quotes
 
 import 'dart:convert';
-import 'dart:typed_data';
-import 'package:freezed_annotation/freezed_annotation.dart';
-
 import 'dart:convert';
-import 'dart:typed_data';
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'dart:ffi' as ffi;
+import 'dart:typed_data';
+import 'dart:typed_data';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'bridge.g.freezed.dart';
 

--- a/lib/src/api/bridge.g.dart
+++ b/lib/src/api/bridge.g.dart
@@ -126,20 +126,25 @@ abstract class FlutterWebrtcNative {
   Future<void> setAudioPlayoutDevice({required String deviceId, dynamic hint});
 
   /// Disposes the specified [`MediaStreamTrack`].
-  Future<void> disposeTrack({required String trackId, dynamic hint});
+  Future<void> disposeTrack(
+      {required String trackId, required MediaType kind, dynamic hint});
 
   /// Changes the [enabled][1] property of the [`MediaStreamTrack`] by its ID.
   ///
   /// [1]: https://w3.org/TR/mediacapture-streams#track-enabled
   Future<void> setTrackEnabled(
-      {required String trackId, required bool enabled, dynamic hint});
+      {required String trackId,
+      required MediaType kind,
+      required bool enabled,
+      dynamic hint});
 
   /// Clones the specified [`MediaStreamTrack`].
-  Future<MediaStreamTrack> cloneTrack({required String trackId, dynamic hint});
+  Future<MediaStreamTrack> cloneTrack(
+      {required String trackId, required MediaType kind, dynamic hint});
 
   /// Registers an observer to the [`MediaStreamTrack`] events.
   Stream<TrackEvent> registerTrackObserver(
-      {required String trackId, dynamic hint});
+      {required String trackId, required MediaType kind, dynamic hint});
 
   /// Sets the provided [`OnDeviceChangeCallback`] as the callback to be called
   /// whenever a set of available media devices changes.
@@ -1108,58 +1113,62 @@ class FlutterWebrtcNativeImpl
         hint: hint,
       ));
 
-  Future<void> disposeTrack({required String trackId, dynamic hint}) =>
+  Future<void> disposeTrack(
+          {required String trackId, required MediaType kind, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_dispose_track(port_, _api2wire_String(trackId)),
+        callFfi: (port_) => inner.wire_dispose_track(
+            port_, _api2wire_String(trackId), _api2wire_media_type(kind)),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "dispose_track",
-          argNames: ["trackId"],
+          argNames: ["trackId", "kind"],
         ),
-        argValues: [trackId],
+        argValues: [trackId, kind],
         hint: hint,
       ));
 
   Future<void> setTrackEnabled(
-          {required String trackId, required bool enabled, dynamic hint}) =>
+          {required String trackId,
+          required MediaType kind,
+          required bool enabled,
+          dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => inner.wire_set_track_enabled(
-            port_, _api2wire_String(trackId), enabled),
+        callFfi: (port_) => inner.wire_set_track_enabled(port_,
+            _api2wire_String(trackId), _api2wire_media_type(kind), enabled),
         parseSuccessData: _wire2api_unit,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "set_track_enabled",
-          argNames: ["trackId", "enabled"],
+          argNames: ["trackId", "kind", "enabled"],
         ),
-        argValues: [trackId, enabled],
+        argValues: [trackId, kind, enabled],
         hint: hint,
       ));
 
   Future<MediaStreamTrack> cloneTrack(
-          {required String trackId, dynamic hint}) =>
+          {required String trackId, required MediaType kind, dynamic hint}) =>
       executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) =>
-            inner.wire_clone_track(port_, _api2wire_String(trackId)),
+        callFfi: (port_) => inner.wire_clone_track(
+            port_, _api2wire_String(trackId), _api2wire_media_type(kind)),
         parseSuccessData: _wire2api_media_stream_track,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "clone_track",
-          argNames: ["trackId"],
+          argNames: ["trackId", "kind"],
         ),
-        argValues: [trackId],
+        argValues: [trackId, kind],
         hint: hint,
       ));
 
   Stream<TrackEvent> registerTrackObserver(
-          {required String trackId, dynamic hint}) =>
+          {required String trackId, required MediaType kind, dynamic hint}) =>
       executeStream(FlutterRustBridgeTask(
         callFfi: (port_) => inner.wire_register_track_observer(
-            port_, _api2wire_String(trackId)),
+            port_, _api2wire_String(trackId), _api2wire_media_type(kind)),
         parseSuccessData: _wire2api_track_event,
         constMeta: const FlutterRustBridgeTaskConstMeta(
           debugName: "register_track_observer",
-          argNames: ["trackId"],
+          argNames: ["trackId", "kind"],
         ),
-        argValues: [trackId],
+        argValues: [trackId, kind],
         hint: hint,
       ));
 
@@ -1967,72 +1976,80 @@ class FlutterWebrtcNativeWire implements FlutterRustBridgeWireBase {
   void wire_dispose_track(
     int port_,
     ffi.Pointer<wire_uint_8_list> track_id,
+    int kind,
   ) {
     return _wire_dispose_track(
       port_,
       track_id,
+      kind,
     );
   }
 
   late final _wire_dispose_trackPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_dispose_track');
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Int32)>>('wire_dispose_track');
   late final _wire_dispose_track = _wire_dispose_trackPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   void wire_set_track_enabled(
     int port_,
     ffi.Pointer<wire_uint_8_list> track_id,
+    int kind,
     bool enabled,
   ) {
     return _wire_set_track_enabled(
       port_,
       track_id,
+      kind,
       enabled ? 1 : 0,
     );
   }
 
   late final _wire_set_track_enabledPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>, ffi.Int32,
               ffi.Uint8)>>('wire_set_track_enabled');
-  late final _wire_set_track_enabled = _wire_set_track_enabledPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
+  late final _wire_set_track_enabled = _wire_set_track_enabledPtr.asFunction<
+      void Function(int, ffi.Pointer<wire_uint_8_list>, int, int)>();
 
   void wire_clone_track(
     int port_,
     ffi.Pointer<wire_uint_8_list> track_id,
+    int kind,
   ) {
     return _wire_clone_track(
       port_,
       track_id,
+      kind,
     );
   }
 
   late final _wire_clone_trackPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Int64, ffi.Pointer<wire_uint_8_list>)>>('wire_clone_track');
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Int32)>>('wire_clone_track');
   late final _wire_clone_track = _wire_clone_trackPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   void wire_register_track_observer(
     int port_,
     ffi.Pointer<wire_uint_8_list> track_id,
+    int kind,
   ) {
     return _wire_register_track_observer(
       port_,
       track_id,
+      kind,
     );
   }
 
   late final _wire_register_track_observerPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Void Function(ffi.Int64,
-              ffi.Pointer<wire_uint_8_list>)>>('wire_register_track_observer');
+          ffi.Void Function(ffi.Int64, ffi.Pointer<wire_uint_8_list>,
+              ffi.Int32)>>('wire_register_track_observer');
   late final _wire_register_track_observer = _wire_register_track_observerPtr
-      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
+      .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>, int)>();
 
   void wire_set_on_device_changed(
     int port_,

--- a/lib/src/api/sender.dart
+++ b/lib/src/api/sender.dart
@@ -60,6 +60,6 @@ class _RtpSenderFFI extends RtpSender {
     await api.senderReplaceTrack(
         peerId: _peerId,
         transceiverIndex: _transceiverId,
-        trackId: t == null ? null : t.id());
+        trackId: t?.id());
   }
 }

--- a/lib/src/api/sender.dart
+++ b/lib/src/api/sender.dart
@@ -58,8 +58,6 @@ class _RtpSenderFFI extends RtpSender {
   @override
   Future<void> replaceTrack(MediaStreamTrack? t) async {
     await api.senderReplaceTrack(
-        peerId: _peerId,
-        transceiverIndex: _transceiverId,
-        trackId: t?.id());
+        peerId: _peerId, transceiverIndex: _transceiverId, trackId: t?.id());
   }
 }

--- a/lib/src/api/sender.dart
+++ b/lib/src/api/sender.dart
@@ -60,6 +60,6 @@ class _RtpSenderFFI extends RtpSender {
     await api.senderReplaceTrack(
         peerId: _peerId,
         transceiverIndex: _transceiverId,
-        trackId: t == null ? null : int.parse(t.id()));
+        trackId: t == null ? null : t.id());
   }
 }

--- a/lib/src/platform/native/media_stream_track.dart
+++ b/lib/src/platform/native/media_stream_track.dart
@@ -144,8 +144,7 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<MediaStreamTrack> clone() async {
     if (!_stopped) {
-      return NativeMediaStreamTrack.from(
-          await api.cloneTrack(trackId: _id));
+      return NativeMediaStreamTrack.from(await api.cloneTrack(trackId: _id));
     } else {
       return NativeMediaStreamTrack.from(ffi.MediaStreamTrack(
           deviceId: _deviceId,

--- a/lib/src/platform/native/media_stream_track.dart
+++ b/lib/src/platform/native/media_stream_track.dart
@@ -134,7 +134,10 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
     _id = track.id.toString();
     _deviceId = track.deviceId;
     _kind = MediaKind.values[track.kind.index];
-    _eventSub = api.registerTrackObserver(trackId: track.id).listen((event) {
+    _eventSub = api
+        .registerTrackObserver(
+            trackId: track.id, kind: ffi.MediaType.values[_kind.index])
+        .listen((event) {
       if (_onEnded != null) {
         _onEnded!();
       }
@@ -144,7 +147,8 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<MediaStreamTrack> clone() async {
     if (!_stopped) {
-      return NativeMediaStreamTrack.from(await api.cloneTrack(trackId: _id));
+      return NativeMediaStreamTrack.from(await api.cloneTrack(
+          trackId: _id, kind: ffi.MediaType.values[_kind.index]));
     } else {
       return NativeMediaStreamTrack.from(ffi.MediaStreamTrack(
           deviceId: _deviceId,
@@ -157,7 +161,8 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> dispose() async {
     if (!_stopped) {
-      await api.disposeTrack(trackId: _id);
+      await api.disposeTrack(
+          trackId: _id, kind: ffi.MediaType.values[_kind.index]);
       await _eventSub?.cancel();
     }
     _stopped = true;
@@ -166,7 +171,10 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> setEnabled(bool enabled) async {
     if (!_stopped) {
-      await api.setTrackEnabled(trackId: _id, enabled: enabled);
+      await api.setTrackEnabled(
+          trackId: _id,
+          enabled: enabled,
+          kind: ffi.MediaType.values[_kind.index]);
     }
 
     _enabled = enabled;
@@ -175,7 +183,8 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> stop() async {
     if (!_stopped) {
-      await api.disposeTrack(trackId: _id);
+      await api.disposeTrack(
+          trackId: _id, kind: ffi.MediaType.values[_kind.index]);
     }
     _stopped = true;
   }

--- a/lib/src/platform/native/media_stream_track.dart
+++ b/lib/src/platform/native/media_stream_track.dart
@@ -145,12 +145,12 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   Future<MediaStreamTrack> clone() async {
     if (!_stopped) {
       return NativeMediaStreamTrack.from(
-          await api.cloneTrack(trackId: int.parse(_id)));
+          await api.cloneTrack(trackId: _id));
     } else {
       return NativeMediaStreamTrack.from(ffi.MediaStreamTrack(
           deviceId: _deviceId,
           enabled: _enabled,
-          id: int.parse(_id),
+          id: _id,
           kind: ffi.MediaType.values[_kind.index]));
     }
   }
@@ -158,7 +158,7 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> dispose() async {
     if (!_stopped) {
-      await api.disposeTrack(trackId: int.parse(_id));
+      await api.disposeTrack(trackId: _id);
       await _eventSub?.cancel();
     }
     _stopped = true;
@@ -167,7 +167,7 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> setEnabled(bool enabled) async {
     if (!_stopped) {
-      await api.setTrackEnabled(trackId: int.parse(_id), enabled: enabled);
+      await api.setTrackEnabled(trackId: _id, enabled: enabled);
     }
 
     _enabled = enabled;
@@ -176,7 +176,7 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> stop() async {
     if (!_stopped) {
-      await api.disposeTrack(trackId: int.parse(_id));
+      await api.disposeTrack(trackId: _id);
     }
     _stopped = true;
   }

--- a/lib/src/platform/native/video_renderer.dart
+++ b/lib/src/platform/native/video_renderer.dart
@@ -162,7 +162,7 @@ class _NativeVideoRendererFFI extends NativeVideoRenderer {
         'textureId': textureId,
       });
 
-      var trackId = int.parse(track.id());
+      var trackId = track.id();
       await api
           .createVideoSink(
               sinkId: sinkId,


### PR DESCRIPTION
## Synopsis

When switching a track, onTrack event occurs with the old track

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests