### PR TITLE
Fix `WebVideoRenderer` not updating `mirror` and `enableContextMenu`

### DIFF
--- a/lib/src/platform/web/video_renderer.dart
+++ b/lib/src/platform/web/video_renderer.dart
@@ -69,7 +69,13 @@ class WebVideoRenderer extends VideoRenderer {
 
   bool mirror = false;
 
-  bool enableContextMenu = true;
+  bool _enableContextMenu = true;
+
+  set enableContextMenu(bool value) {
+    if (_enableContextMenu == value) return;
+    _enableContextMenu = value;
+    findHtmlView()?.setAttribute('oncontextmenu', value ? '' : 'return false;');
+  }
 
   final _subscriptions = <StreamSubscription>[];
 
@@ -191,7 +197,7 @@ class WebVideoRenderer extends VideoRenderer {
         ..id = _elementIdForVideo
         ..setAttribute('playsinline', 'true')
         ..setAttribute(
-            'oncontextmenu', enableContextMenu ? '' : 'return false;');
+            'oncontextmenu', _enableContextMenu ? '' : 'return false;');
 
       _subscriptions.add(
         element.onCanPlay.listen((dynamic _) {

--- a/lib/src/platform/web/video_renderer.dart
+++ b/lib/src/platform/web/video_renderer.dart
@@ -67,7 +67,14 @@ class WebVideoRenderer extends VideoRenderer {
 
   final int _textureId;
 
-  bool mirror = false;
+  bool _mirror = false;
+
+  @override
+  set mirror(bool value) {
+    if (_mirror == value) return;
+    _mirror = value;
+    findHtmlView()?.style.transform = value ? 'rotateY(0.5turn)' : '';
+  }
 
   bool _enableContextMenu = true;
 
@@ -192,7 +199,7 @@ class WebVideoRenderer extends VideoRenderer {
         ..style.border = 'none'
         ..style.width = '100%'
         ..style.height = '100%'
-        ..style.transform = mirror ? 'rotateY(0.5turn)' : ''
+        ..style.transform = _mirror ? 'rotateY(0.5turn)' : ''
         ..srcObject = _videoStream
         ..id = _elementIdForVideo
         ..setAttribute('playsinline', 'true')


### PR DESCRIPTION
## Synopsis

This PR fixes `WebVideoRenderer` not applying `mirror` and `enableContextMenu` values in its HTML element.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests