### PR TITLE
Fix use after dispose transceiver

### DIFF
--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -353,21 +353,9 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
           "Microphone permissions was not granted", GetUserMediaException.Kind.Audio)
     }
 
-    if (audioTracks[constraints] != null) {
-      val track = audioTracks[constraints]!!.fork()
-      audioTracks[constraints] = track
-      track.onStop({ audioTracks.remove(constraints) })
-
-      return track
-    }
-
     val source = state.getPeerConnectionFactory().createAudioSource(constraints.intoWebRtc())
     val audioTrackSource = AudioMediaTrackSource(source, state.getPeerConnectionFactory())
 
-    val track = audioTrackSource.newTrack()
-    track.onStop({ audioTracks.remove(constraints) })
-    audioTracks[constraints] = track
-
-    return track
+    return audioTrackSource.newTrack()
   }
 }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -352,10 +352,8 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
       throw GetUserMediaException(
           "Microphone permissions was not granted", GetUserMediaException.Kind.Audio)
     }
-
     val source = state.getPeerConnectionFactory().createAudioSource(constraints.intoWebRtc())
     val audioTrackSource = AudioMediaTrackSource(source, state.getPeerConnectionFactory())
-
     return audioTrackSource.newTrack()
   }
 }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -352,8 +352,22 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
       throw GetUserMediaException(
           "Microphone permissions was not granted", GetUserMediaException.Kind.Audio)
     }
+
+    if (audioTracks[constraints] != null) {
+      val track = audioTracks[constraints]!!.fork()
+      audioTracks[constraints] = track
+      track.onStop({ audioTracks.remove(constraints) })
+
+      return track
+    }
+
     val source = state.getPeerConnectionFactory().createAudioSource(constraints.intoWebRtc())
     val audioTrackSource = AudioMediaTrackSource(source, state.getPeerConnectionFactory())
-    return audioTrackSource.newTrack()
+
+    val track = audioTrackSource.newTrack()
+    track.onStop({ audioTracks.remove(constraints) })
+    audioTracks[constraints] = track
+
+    return track
   }
 }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/RtpReceiverProxy.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/RtpReceiverProxy.kt
@@ -15,6 +15,7 @@ class RtpReceiverProxy(receiver: RtpReceiver) : Proxy<RtpReceiver>(receiver) {
   val id: String = obj.id()
 
   init {
+    id = obj.id()
     track.replace(obj.track()!!)
     addOnSyncListener { track.replace(obj.track()!!) }
   }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/RtpReceiverProxy.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/RtpReceiverProxy.kt
@@ -15,7 +15,6 @@ class RtpReceiverProxy(receiver: RtpReceiver) : Proxy<RtpReceiver>(receiver) {
   val id: String = obj.id()
 
   init {
-    id = obj.id()
     track.replace(obj.track()!!)
     addOnSyncListener { track.replace(obj.track()!!) }
   }

--- a/crates/native/src/api.rs
+++ b/crates/native/src/api.rs
@@ -1006,8 +1006,7 @@ pub fn dispose_peer_connection(peer_id: u64) {
 /// Creates a [`MediaStream`] with tracks according to provided
 /// [`MediaStreamConstraints`].
 pub fn get_media(constraints: MediaStreamConstraints) -> GetMediaResult {
-    let lock = WEBRTC.lock().unwrap().get_media(constraints);
-    match lock {
+    match WEBRTC.lock().unwrap().get_media(constraints) {
         Ok(tracks) => GetMediaResult::Ok(tracks),
         Err(err) => GetMediaResult::Err(err),
     }

--- a/crates/native/src/pc.rs
+++ b/crates/native/src/pc.rs
@@ -629,9 +629,8 @@ impl Webrtc {
             }
 
             let peer = peer.inner.lock().unwrap();
-            let transceivers = peer.get_transceivers();
 
-            for trnscvr in transceivers {
+            for trnscvr in peer.get_transceivers() {
                 let sender = trnscvr.sender();
                 match trnscvr.media_type() {
                     sys::MediaType::MEDIA_TYPE_VIDEO => {


### PR DESCRIPTION
## Synopsis

PeerConnection can use the transceiver after it has been disposed.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [ ] Documentation is updated (if required)
- [ ] Tests are updated (if required)
- [ ] Changes conform code style
- [ ] CHANGELOG entry is added (if required)
- [ ] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests