### PR TITLE
Fix macOS version

### DIFF
--- a/crates/native/build.rs
+++ b/crates/native/build.rs
@@ -5,8 +5,9 @@ use std::{env, path::PathBuf, process};
 
 #[allow(clippy::unnecessary_wraps)]
 fn main() -> anyhow::Result<()> {
-    #[cfg(target_os = "macos")]
-    {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if taget_os == "macos" {
+        println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.11");
         println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
         println!(
             "cargo:rustc-link-arg=-Wl,-install_name,\


### PR DESCRIPTION
## Synopsis

Currently we're not explicitly set macOS version, so rust compiler choices this version based on system on which build is happen. So we need to fix this and explicitly set this version with `MACOSX_DEPLOYMENT_TARGET` env var.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [ ] and approved
- [ ] [Review][l:2] is completed and changes are approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] `Draft: ` prefix is removed
    - [ ] All temporary labels are removed
  
[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests