### PR TITLE
Fix output audio switching on Mac

### DIFF
--- a/crates/libwebrtc-sys/include/bridge.h
+++ b/crates/libwebrtc-sys/include/bridge.h
@@ -167,17 +167,17 @@ int32_t recording_device_name(const AudioDeviceModule& audio_device_module,
 int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
                                    uint16_t index);
 
-// Stops playout of audio on device.
+// Stops playout of audio on the specified device.
 int32_t stop_playout(const AudioDeviceModule& audio_device_module);
 
-// Sets stereo availability of playout device.
+// Sets stereo availability of the specified playout device.
 int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module,
                                     bool available);
 
-// Initializes audio playout device.
+// Initializes the specified audio playout device.
 int32_t init_playout(const AudioDeviceModule& audio_device_module);
 
-// Starts audio playout device playing.
+// Starts playout of audio on the specified device.
 int32_t start_playout(const AudioDeviceModule& audio_device_module);
 
 // Specifies which device to use for playout audio using an index

--- a/crates/libwebrtc-sys/include/bridge.h
+++ b/crates/libwebrtc-sys/include/bridge.h
@@ -167,6 +167,19 @@ int32_t recording_device_name(const AudioDeviceModule& audio_device_module,
 int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
                                    uint16_t index);
 
+// Stops playout of audio on device.
+int32_t stop_playout(const AudioDeviceModule& audio_device_module);
+
+// Sets stereo availability of playout device.
+int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module,
+                                    bool available);
+
+// Initializes audio playout device.
+int32_t init_playout(const AudioDeviceModule& audio_device_module);
+
+// Starts audio playout device playing.
+int32_t start_playout(const AudioDeviceModule& audio_device_module);
+
 // Specifies which device to use for playout audio using an index
 // retrieved by the corresponding enumeration method which is
 // `AudiDeviceModule::PlayoutDeviceName`.

--- a/crates/libwebrtc-sys/src/bridge.rs
+++ b/crates/libwebrtc-sys/src/bridge.rs
@@ -1311,6 +1311,21 @@ pub(crate) mod webrtc {
             index: u16,
         ) -> i32;
 
+        /// Stops playout of audio on device.
+        pub fn stop_playout(audio_device_module: &AudioDeviceModule) -> i32;
+
+        /// Sets stereo availability of playout device.
+        pub fn stereo_playout_is_available(
+            audio_device_module: &AudioDeviceModule,
+            available: bool,
+        ) -> i32;
+
+        /// Initializes audio playout device.
+        pub fn init_playout(audio_device_module: &AudioDeviceModule) -> i32;
+
+        /// Starts audio playout device playing.
+        pub fn start_playout(audio_device_module: &AudioDeviceModule) -> i32;
+
         /// Specifies which speaker to use for playing out audio using an index
         /// retrieved by the corresponding enumeration method
         /// [`AudiDeviceModule::PlayoutDeviceName`].

--- a/crates/libwebrtc-sys/src/bridge.rs
+++ b/crates/libwebrtc-sys/src/bridge.rs
@@ -1311,19 +1311,19 @@ pub(crate) mod webrtc {
             index: u16,
         ) -> i32;
 
-        /// Stops playout of audio on device.
+        /// Stops playout of audio on the given device.
         pub fn stop_playout(audio_device_module: &AudioDeviceModule) -> i32;
 
-        /// Sets stereo availability of playout device.
+        /// Sets stereo availability of the given playout device.
         pub fn stereo_playout_is_available(
             audio_device_module: &AudioDeviceModule,
             available: bool,
         ) -> i32;
 
-        /// Initializes audio playout device.
+        /// Initializes the given audio playout device.
         pub fn init_playout(audio_device_module: &AudioDeviceModule) -> i32;
 
-        /// Starts audio playout device playing.
+        /// Starts playout of audio on the given device.
         pub fn start_playout(audio_device_module: &AudioDeviceModule) -> i32;
 
         /// Specifies which speaker to use for playing out audio using an index

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -222,6 +222,22 @@ int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
   return audio_device_module->SetRecordingDevice(index);
 }
 
+int32_t stop_playout(const AudioDeviceModule& audio_device_module) {
+  return audio_device_module->StopPlayout();
+}
+
+int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module, bool available) {
+  return audio_device_module->StereoPlayoutIsAvailable(&available);
+}
+
+int32_t init_playout(const AudioDeviceModule& audio_device_module) {
+  return audio_device_module->InitPlayout();
+}
+
+int32_t start_playout(const AudioDeviceModule& audio_device_module) {
+  return audio_device_module->StartPlayout();
+}
+
 // Calls `AudioDeviceModule->SetPlayoutDevice()` with the provided device index.
 int32_t set_audio_playout_device(const AudioDeviceModule& audio_device_module,
                                  uint16_t index) {

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -222,23 +222,23 @@ int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
   return audio_device_module->SetRecordingDevice(index);
 }
 
-// Stops playout of audio on device.
+// Stops playout of audio on the specified device.
 int32_t stop_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->StopPlayout();
 }
 
-// Sets stereo availability of playout device.
+// Sets stereo availability of the specified playout device.
 int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module,
                                     bool available) {
   return audio_device_module->StereoPlayoutIsAvailable(&available);
 }
 
-// Initializes audio playout device.
+// Initializes the specified audio playout device.
 int32_t init_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->InitPlayout();
 }
 
-// Starts audio playout device playing.
+// Starts playout of audio on the specified device.
 int32_t start_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->StartPlayout();
 }

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -225,7 +225,13 @@ int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
 // Calls `AudioDeviceModule->SetPlayoutDevice()` with the provided device index.
 int32_t set_audio_playout_device(const AudioDeviceModule& audio_device_module,
                                  uint16_t index) {
-  return audio_device_module->SetPlayoutDevice(index);
+  audio_device_module->StopPlayout();
+  int32_t result = audio_device_module->SetPlayoutDevice(index);
+  bool available = false;
+  audio_device_module->StereoPlayoutIsAvailable(&available);
+  audio_device_module->InitPlayout();
+  audio_device_module->StartPlayout();
+  return result;
 }
 
 // Calls `AudioProcessingBuilder().Create()`.

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -222,18 +222,22 @@ int32_t set_audio_recording_device(const AudioDeviceModule& audio_device_module,
   return audio_device_module->SetRecordingDevice(index);
 }
 
+// Stops playout of audio on device.
 int32_t stop_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->StopPlayout();
 }
 
+// Sets stereo availability of playout device.
 int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module, bool available) {
   return audio_device_module->StereoPlayoutIsAvailable(&available);
 }
 
+// Initializes audio playout device.
 int32_t init_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->InitPlayout();
 }
 
+// Starts audio playout device playing.
 int32_t start_playout(const AudioDeviceModule& audio_device_module) {
   return audio_device_module->StartPlayout();
 }
@@ -241,13 +245,7 @@ int32_t start_playout(const AudioDeviceModule& audio_device_module) {
 // Calls `AudioDeviceModule->SetPlayoutDevice()` with the provided device index.
 int32_t set_audio_playout_device(const AudioDeviceModule& audio_device_module,
                                  uint16_t index) {
-  audio_device_module->StopPlayout();
-  int32_t result = audio_device_module->SetPlayoutDevice(index);
-  bool available = false;
-  audio_device_module->StereoPlayoutIsAvailable(&available);
-  audio_device_module->InitPlayout();
-  audio_device_module->StartPlayout();
-  return result;
+  return audio_device_module->SetPlayoutDevice(index);
 }
 
 // Calls `AudioProcessingBuilder().Create()`.

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -228,7 +228,8 @@ int32_t stop_playout(const AudioDeviceModule& audio_device_module) {
 }
 
 // Sets stereo availability of playout device.
-int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module, bool available) {
+int32_t stereo_playout_is_available(const AudioDeviceModule& audio_device_module,
+                                    bool available) {
   return audio_device_module->StereoPlayoutIsAvailable(&available);
 }
 

--- a/crates/libwebrtc-sys/src/lib.rs
+++ b/crates/libwebrtc-sys/src/lib.rs
@@ -326,6 +326,58 @@ impl AudioDeviceModule {
         Ok(())
     }
 
+    /// Stops playout of audio on device.
+    pub fn stop_playout(&self) -> anyhow::Result<()> {
+        let result = webrtc::stop_playout(&self.0);
+
+        if result != 0 {
+            bail!("`AudioDeviceModule::StopPlayout` failed with {result} code");
+        }
+
+        Ok(())
+    }
+
+    /// Sets stereo availability of playout device.
+    pub fn stereo_playout_is_available(
+        &self,
+        available: bool,
+    ) -> anyhow::Result<()> {
+        let result = webrtc::stereo_playout_is_available(&self.0, available);
+
+        if result != 0 {
+            bail!(
+                "`AudioDeviceModule::StereoPlayoutIsAvailable` failed with \
+                {result} code"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Initializes audio playout device.
+    pub fn init_playout(&self) -> anyhow::Result<()> {
+        let result = webrtc::init_playout(&self.0);
+
+        if result != 0 {
+            bail!("`AudioDeviceModule::InitPlayout` failed with {result} code");
+        }
+
+        Ok(())
+    }
+
+    /// Starts audio playout device playing.
+    pub fn start_playout(&self) -> anyhow::Result<()> {
+        let result = webrtc::start_playout(&self.0);
+
+        if result != 0 {
+            bail!(
+                "`AudioDeviceModule::StartPlayout` failed with {result} code"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Initializes the microphone in the [`AudioDeviceModule`].
     pub fn init_microphone(&self) -> anyhow::Result<()> {
         let result = webrtc::init_microphone(&self.0);

--- a/crates/libwebrtc-sys/src/lib.rs
+++ b/crates/libwebrtc-sys/src/lib.rs
@@ -326,7 +326,7 @@ impl AudioDeviceModule {
         Ok(())
     }
 
-    /// Stops playout of audio on device.
+    /// Stops playout of audio on this device.
     pub fn stop_playout(&self) -> anyhow::Result<()> {
         let result = webrtc::stop_playout(&self.0);
 
@@ -337,7 +337,7 @@ impl AudioDeviceModule {
         Ok(())
     }
 
-    /// Sets stereo availability of playout device.
+    /// Sets stereo availability of this playout device.
     pub fn stereo_playout_is_available(
         &self,
         available: bool,
@@ -347,14 +347,14 @@ impl AudioDeviceModule {
         if result != 0 {
             bail!(
                 "`AudioDeviceModule::StereoPlayoutIsAvailable` failed with \
-                {result} code"
+                 {result} code"
             );
         }
 
         Ok(())
     }
 
-    /// Initializes audio playout device.
+    /// Initializes this audio playout device.
     pub fn init_playout(&self) -> anyhow::Result<()> {
         let result = webrtc::init_playout(&self.0);
 
@@ -365,13 +365,13 @@ impl AudioDeviceModule {
         Ok(())
     }
 
-    /// Starts audio playout device playing.
+    /// Starts playout of audio on this device.
     pub fn start_playout(&self) -> anyhow::Result<()> {
         let result = webrtc::start_playout(&self.0);
 
         if result != 0 {
             bail!(
-                "`AudioDeviceModule::StartPlayout` failed with {result} code"
+                "`AudioDeviceModule::StartPlayout` failed with {result} code",
             );
         }
 

--- a/crates/native/src/devices.rs
+++ b/crates/native/src/devices.rs
@@ -278,7 +278,13 @@ impl Webrtc {
         let index = self.get_index_of_audio_playout_device(&device_id)?;
 
         if let Some(index) = index {
-            self.audio_device_module.set_playout_device(index)
+            let adm = &self.audio_device_module;
+            adm.stop_playout()?;
+            adm.set_playout_device(index)?;
+            adm.stereo_playout_is_available(false)?;
+            adm.init_playout()?;
+            adm.start_playout()?;
+            Ok(())
         } else {
             Err(anyhow!("Cannot find playout device with ID `{device_id}`"))
         }

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -841,7 +841,7 @@ impl AudioDeviceModule {
         Ok(())
     }
 
-    /// Stops playout of audio on device.
+    /// Stops playout of audio on this [`AudioDeviceModule`].
     ///
     /// # Errors
     ///
@@ -850,7 +850,7 @@ impl AudioDeviceModule {
         self.inner.stop_playout()
     }
 
-    /// Sets stereo availability of playout device.
+    /// Sets stereo availability of this playout [`AudioDeviceModule`].
     ///
     /// # Errors
     ///
@@ -862,7 +862,7 @@ impl AudioDeviceModule {
         self.inner.stereo_playout_is_available(available)
     }
 
-    /// Initializes audio playout device.
+    /// Initializes this playout [`AudioDeviceModule`].
     ///
     /// # Errors
     ///
@@ -871,7 +871,7 @@ impl AudioDeviceModule {
         self.inner.init_playout()
     }
 
-    /// Starts audio playout device playing.
+    /// Starts playout of audio on this [`AudioDeviceModule`].
     ///
     /// # Errors
     ///

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -847,9 +847,7 @@ impl AudioDeviceModule {
     ///
     /// If [`sys::AudioDeviceModule::stop_playout()`] call fails.
     pub fn stop_playout(&self) -> anyhow::Result<()> {
-        self.inner.stop_playout()?;
-
-        Ok(())
+        self.inner.stop_playout()
     }
 
     /// Sets stereo availability of playout device.
@@ -861,9 +859,7 @@ impl AudioDeviceModule {
         &self,
         available: bool,
     ) -> anyhow::Result<()> {
-        self.inner.stereo_playout_is_available(available)?;
-
-        Ok(())
+        self.inner.stereo_playout_is_available(available)
     }
 
     /// Initializes audio playout device.
@@ -872,9 +868,7 @@ impl AudioDeviceModule {
     ///
     /// If [`sys::AudioDeviceModule::init_playout()`] call fails.
     pub fn init_playout(&self) -> anyhow::Result<()> {
-        self.inner.init_playout()?;
-
-        Ok(())
+        self.inner.init_playout()
     }
 
     /// Starts audio playout device playing.
@@ -883,9 +877,7 @@ impl AudioDeviceModule {
     ///
     /// If [`sys::AudioDeviceModule::start_playout()`] call fails.
     pub fn start_playout(&self) -> anyhow::Result<()> {
-        self.inner.start_playout()?;
-
-        Ok(())
+        self.inner.start_playout()
     }
 }
 

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -840,6 +840,53 @@ impl AudioDeviceModule {
 
         Ok(())
     }
+
+    /// Stops playout of audio on device.
+    ///
+    /// # Errors
+    ///
+    /// If [`sys::AudioDeviceModule::stop_playout()`] call fails.
+    pub fn stop_playout(&self) -> anyhow::Result<()> {
+        self.inner.stop_playout()?;
+
+        Ok(())
+    }
+
+    /// Sets stereo availability of playout device.
+    ///
+    /// # Errors
+    ///
+    /// If [`sys::AudioDeviceModule::stereo_playout_is_available()`] call fails.
+    pub fn stereo_playout_is_available(
+        &self,
+        available: bool,
+    ) -> anyhow::Result<()> {
+        self.inner.stereo_playout_is_available(available)?;
+
+        Ok(())
+    }
+
+    /// Initializes audio playout device.
+    ///
+    /// # Errors
+    ///
+    /// If [`sys::AudioDeviceModule::init_playout()`] call fails.
+    pub fn init_playout(&self) -> anyhow::Result<()> {
+        self.inner.init_playout()?;
+
+        Ok(())
+    }
+
+    /// Starts audio playout device playing.
+    ///
+    /// # Errors
+    ///
+    /// If [`sys::AudioDeviceModule::start_playout()`] call fails.
+    pub fn start_playout(&self) -> anyhow::Result<()> {
+        self.inner.start_playout()?;
+
+        Ok(())
+    }
 }
 
 /// Possible kinds of media track's source.


### PR DESCRIPTION
## Synopsis

Currently, `setOutputAudioId` on MacOS is not working. This is because we're no stopping playout before changing audio output.




## Solution

We need to stop playout before switching output audio device, and start playing again after it.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
