### PR TITLE
Use our libwebrtc build from CocoaPods on iOS

### DIFF
--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -130,7 +130,7 @@ fn get_expected_libwebrtc_hash() -> anyhow::Result<&'static str> {
 fn libpath() -> anyhow::Result<PathBuf> {
     let target = get_target()?;
     let manifest_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-    Ok(manifest_path.join("lib").join(&target))
+    Ok(manifest_path.join("lib").join(target))
 }
 
 /// Downloads and unpacks compiled `libwebrtc` library.
@@ -184,7 +184,7 @@ fn download_libwebrtc() -> anyhow::Result<()> {
 
     // Download the compiled `libwebrtc` archive.
     {
-        let mut resp = BufReader::new(reqwest::blocking::get(&format!(
+        let mut resp = BufReader::new(reqwest::blocking::get(format!(
             "{LIBWEBRTC_URL}/{tar_file}"
         ))?);
         let mut out_file = BufWriter::new(fs::File::create(&archive)?);

--- a/ios/medea_flutter_webrtc.podspec
+++ b/ios/medea_flutter_webrtc.podspec
@@ -16,7 +16,8 @@ Flutter WebRTC plugin based on Google WebRTC.
   s.source_files     = 'Classes/**/*'
   s.dependency 'Flutter'
   # TODO: We should use `instrumentisto/libwebrtc-bin`.
-  s.dependency 'WebRTC-SDK', '104.5112.04'
+  # s.dependency 'WebRTC-SDK', '104.5112.04'
+  s.dependency 'instrumentisto-libwebrtc-bin', '108.0.5359.124'
   s.dependency 'libyuv-iOS'
   s.platform         = :ios, '13.0'
   s.static_framework = true

--- a/ios/medea_flutter_webrtc.podspec
+++ b/ios/medea_flutter_webrtc.podspec
@@ -15,8 +15,6 @@ Flutter WebRTC plugin based on Google WebRTC.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'Flutter'
-  # TODO: We should use `instrumentisto/libwebrtc-bin`.
-  # s.dependency 'WebRTC-SDK', '104.5112.04'
   s.dependency 'instrumentisto-libwebrtc-bin', '108.0.5359.124'
   s.dependency 'libyuv-iOS'
   s.platform         = :ios, '13.0'


### PR DESCRIPTION
## Synopsis

This PR migrates flutter-webrtc to using our WebRTC build on iOS.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
