### PR TITLE
Fire onDeviceChange when default audio device is changed on MacOS

### DIFF
--- a/crates/native/src/media_devices.m
+++ b/crates/native/src/media_devices.m
@@ -25,6 +25,16 @@ void set_on_device_change_mac(void(*cb)()) {
   AudioObjectAddPropertyListener(kAudioObjectSystemObject,
                                  &outputDeviceAddress,
                                  &callbackFunction, cb);
+  
+  AudioObjectPropertyAddress inputDeviceAddress = {
+    kAudioHardwarePropertyDefaultInputDevice,
+    kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyElementMaster
+  };
+  AudioObjectAddPropertyListener(kAudioObjectSystemObject,
+                                 &inputDeviceAddress,
+                                 &callbackFunction, cb);
+  
   NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
   [notificationCenter addObserverForName:AVCaptureDeviceWasConnectedNotification
       object:nil

--- a/crates/native/src/media_devices.m
+++ b/crates/native/src/media_devices.m
@@ -1,9 +1,30 @@
 #include "media_devices.h"
 
 #ifdef __APPLE__
+// Callback for default output audio device changes.
+//
+// Just calls `onDeviceChange` callback.
+OSStatus callbackFunction(AudioObjectID inObjectID,
+                            UInt32 inNumberAddresses,
+                            const AudioObjectPropertyAddress inAddresses[],
+                            void *inClientData) {
+    void (*callback)() = (void (*)())inClientData;
+    callback();
+    return 0;
+}
+
 // Registers the provided function to be called when `NSNotificationCenter`
-// detects that an `AVCaptureDevice` was connected or disconnected.
+// detects that an `AVCaptureDevice` was connected or disconnected or default
+// output audio device was changed.
 void set_on_device_change_mac(void(*cb)()) {
+  AudioObjectPropertyAddress outputDeviceAddress = {
+    kAudioHardwarePropertyDefaultOutputDevice,
+    kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyElementMaster
+  };
+  AudioObjectAddPropertyListener(kAudioObjectSystemObject,
+                                 &outputDeviceAddress,
+                                 &callbackFunction, cb);
   NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
   [notificationCenter addObserverForName:AVCaptureDeviceWasConnectedNotification
       object:nil


### PR DESCRIPTION
## Synopsis

Currently, application will not automatically change audio device when user changes audio device in system settings on MacOS. So, for example, if user takes AirPods out from ear, then audio continues to play in the ear-piece, even if audio device is set to default. Or if user simply changes audio device in system settings.




## Solution

This PR implements functional which will fire `onDeviceChange` callback when default audio device is changed by user (or the system).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
