### PR TITLE
Rename `shouldRotate` to `autoRotate` in `VideoView` on Web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "atomic"
@@ -272,14 +272,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge_macros"
-version = "1.62.0"
+version = "1.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d16ed2ee35d1c3262bbaade18386ab4ee7a17454e86d511dd564bd029373f92"
+checksum = "0aaf0be361a22086b97f81a3dfe8e433ec70cb70bc8803b835ddef42c7c23094"
 
 [[package]]
 name = "fnv"
@@ -895,9 +895,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1048,9 +1048,9 @@ checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",

--- a/crates/native/Cargo.toml
+++ b/crates/native/Cargo.toml
@@ -17,14 +17,14 @@ flutter_rust_bridge = { version = "=1.54.0", default-features = false }
 lazy_static = "1.4"
 libwebrtc-sys = { path = "../libwebrtc-sys" }
 log = "0.4"
-once_cell = "1.16"
+once_cell = "1.17"
 threadpool = "1.8"
 xxhash = { package = "xxhash-rust", version = "0.8", features = ["xxh3"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libudev = "0.3"
 nix = { version = "0.26", features = ["poll"] }
-pulse = { version = "2.26", package = "libpulse-binding" }
+pulse = { version = "2.27", package = "libpulse-binding" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["dbt", "winuser"] }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -424,7 +424,7 @@ packages:
       name: puppeteer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.21.0"
+    version: "2.22.0"
   shelf:
     dependency: transitive
     description:

--- a/ios/Classes/controller/PeerEventController.swift
+++ b/ios/Classes/controller/PeerEventController.swift
@@ -23,7 +23,7 @@ class PeerEventController: PeerEventObserver {
       "transceiver": RtpTransceiverController(messenger: self.messenger,
                                               transceiver: transceiver)
         .asFlutterResult(),
-      ])
+    ])
   }
 
   /// Sends an `onIceConnectionStateChange` event to Flutter side.

--- a/ios/Classes/controller/PeerEventController.swift
+++ b/ios/Classes/controller/PeerEventController.swift
@@ -23,7 +23,7 @@ class PeerEventController: PeerEventObserver {
       "transceiver": RtpTransceiverController(messenger: self.messenger,
                                               transceiver: transceiver)
         .asFlutterResult(),
-    ])
+      ])
   }
 
   /// Sends an `onIceConnectionStateChange` event to Flutter side.

--- a/lib/src/platform/web/video_view.dart
+++ b/lib/src/platform/web/video_view.dart
@@ -13,7 +13,7 @@ class VideoView extends StatefulWidget {
     this.mirror = false,
     this.enableContextMenu = true,
     this.filterQuality = FilterQuality.low,
-    this.shouldRotate = false,
+    this.autoRotate = false,
   }) : super(key: key);
 
   final VideoRenderer _renderer;
@@ -21,7 +21,7 @@ class VideoView extends StatefulWidget {
   final bool mirror;
   final bool enableContextMenu;
   final FilterQuality filterQuality;
-  final bool shouldRotate;
+  final bool autoRotate;
 
   @override
   State<VideoView> createState() => _VideoViewState();


### PR DESCRIPTION
## Synopsis

При попытке забилдить приложение в вебе с использованием параметра `autoRotate` стреляет следующая ошибка:
```
lib/ui/page/call/widget/video_view.dart:187:7: Error: No named parameter with the name 'autoRotate'.
      autoRotate: !widget.mirror,
      ^^^^^^^^^^
../../../.pub-cache/hosted/pub.dev/medea_flutter_webrtc-0.8.0-dev+rev.4aa05d31f5ff998b841100353c409a398b8b0a76/lib/src/platform/web/video_view.dart:9:9:
Context: Found this candidate, but the arguments don't match.
  const VideoView(
```

Связана она с тем, что в вебовском `VideoView` этот параметр называется `shouldRotate`, а в нативной - `autoRotate`.




## Solution

Переименовать `shouldRotate` в `autoRotate`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
